### PR TITLE
Allow headers to be optionally specified

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.alfasoftware</groupId>
   <artifactId>soapstone</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 
   <name>soapstone</name>
   <description>soapstone is a library for exposing API catalogues of JAX-WS SOAP web services as JSON/HTTP.</description>

--- a/src/test/java/org/alfasoftware/soapstone/TestWebServiceClass.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestWebServiceClass.java
@@ -113,6 +113,25 @@ public class TestWebServiceClass {
 
 
   /**
+   * Test that headers are treated as optional. An invocation should not fail if there are missing header parameters.
+   */
+  @Test
+  public void testInvokeOperationWhenHeaderParamsAbsent() {
+
+    // Given
+    nonHeaderParameters.put("parameter", "parameterValue");
+
+    // When
+    Object object = webServiceClass.invokeOperation("methodWithCorrectlyAnnotatedHeaderParam", nonHeaderParameters, headerParameters);
+
+    // Then
+    assertEquals("The method was not invoked", EXPECTED_RESPONSE, object.toString());
+
+
+  }
+
+
+  /**
    * Tests that the {@link WebServiceClass#invokeOperation(String, Map, Map)} method correctly throws a
    * relevant {@link WebApplicationException} when appropriate.
    */


### PR DESCRIPTION
From https://github.com/alfasoftware/soapstone/issues/12:
> Parameters identified by
@WebParam(header = true)
are not treated as optional and must be provided, or a 404 is produced.