### PR TITLE
Type parameters lost on conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.alfasoftware</groupId>
   <artifactId>soapstone</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.3</version>
 
   <name>soapstone</name>
   <description>soapstone is a library for exposing API catalogues of JAX-WS SOAP web services as JSON/HTTP.</description>
@@ -81,15 +81,30 @@
       <version>2.1</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>2.9.3</version>
+    </dependency>
+       <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
+      <groupId>ognl</groupId>
+      <artifactId>ognl</artifactId>
+      <version>2.6.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>27.0.1-jre</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.9.3</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -116,29 +131,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-    </dependency>
-    <dependency>
-      <groupId>ognl</groupId>
-      <artifactId>ognl</artifactId>
-      <version>2.6.9</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>27.0.1-jre</version>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>hk2-api</artifactId>
       <version>2.2.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-api</artifactId>
-      <version>2.2.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,16 @@
       <artifactId>guava</artifactId>
       <version>27.0.1-jre</version>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-api</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-api</artifactId>
+      <version>2.2.0</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/main/java/org/alfasoftware/soapstone/WebServiceClass.java
+++ b/src/main/java/org/alfasoftware/soapstone/WebServiceClass.java
@@ -1,225 +1,234 @@
-/* Copyright 2019 Alfa Financial Software
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.alfasoftware.soapstone;
+  /* Copyright 2019 Alfa Financial Software
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+  package org.alfasoftware.soapstone;
 
-import javax.jws.WebMethod;
-import javax.jws.WebParam;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.Response;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
+  import static org.alfasoftware.soapstone.Mappers.INSTANCE;
 
-/**
- * A wrapper around a class representing a web service endpoint
- *
- * @param <T> the type of the wrapped class
- *
- * @author Copyright (c) Alfa Financial Software 2019
- */
-public class WebServiceClass<T> {
+  import java.io.IOException;
+  import java.lang.reflect.InvocationTargetException;
+  import java.lang.reflect.Method;
+  import java.lang.reflect.Modifier;
+  import java.lang.reflect.Parameter;
+  import java.util.Arrays;
+  import java.util.HashMap;
+  import java.util.HashSet;
+  import java.util.List;
+  import java.util.Locale;
+  import java.util.Map;
+  import java.util.Optional;
+  import java.util.Set;
+  import java.util.function.Supplier;
+  import java.util.stream.Collectors;
 
-  private final Class<T> klass;
-  private final Supplier<T> instance;
+  import javax.jws.WebMethod;
+  import javax.jws.WebParam;
+  import javax.ws.rs.BadRequestException;
+  import javax.ws.rs.InternalServerErrorException;
+  import javax.ws.rs.NotFoundException;
+  import javax.ws.rs.core.Response;
 
-  private final TypeConverter typeConverter = new TypeConverter(Locale.getDefault());
-
+  import com.fasterxml.jackson.databind.JavaType;
 
   /**
-   * Create a new WebServiceClass for a class representing a web service endpoint
+   * A wrapper around a class representing a web service endpoint
    *
-   * @param klass the class for which to create
-   * @param instanceSupplier a supplier of an instance of klass
-   * @param <U> type of klass
-   * @return a new WebServiceClass
+   * @param <T> the type of the wrapped class
+   * @author Copyright (c) Alfa Financial Software 2019
    */
-  public static <U> WebServiceClass<U> forClass(Class<U> klass, Supplier<U> instanceSupplier) {
-    return new WebServiceClass<>(klass, instanceSupplier);
-  }
+  public class WebServiceClass<T> {
+
+    private final Class<T> klass;
+    private final Supplier<T> instance;
+
+    private final TypeConverter typeConverter = new TypeConverter(Locale.getDefault());
 
 
-  private WebServiceClass(Class<T> klass, Supplier<T> instanceSupplier) {
-    this.klass = klass;
-    this.instance  = instanceSupplier;
-  }
+    /**
+     * Create a new WebServiceClass for a class representing a web service endpoint
+     *
+     * @param klass            the class for which to create
+     * @param instanceSupplier a supplier of an instance of klass
+     * @param <U>              type of klass
+     * @return a new WebServiceClass
+     */
+    public static <U> WebServiceClass<U> forClass(Class<U> klass, Supplier<U> instanceSupplier) {
+      return new WebServiceClass<>(klass, instanceSupplier);
+    }
 
 
-  /**
-   * Invoke the web service operation and return its return value
-   *
-   * <p>
-   * The return value conforms to that stated for {@link Method#invoke(Object, Object...)},
-   * e.g., will be null if the underlying return type is void; will be boxed if the underlying
-   * return type is primitive.
-   *
-   * @param operationName Name of the operation
-   * @param parameters Parameters
-   * @param headerParameters Headers
-   *
-   * @return the return value of the operation
-   */
-  Object invokeOperation(String operationName, Map<String, String> parameters, Map<String, String> headerParameters) {
+    private WebServiceClass(Class<T> klass, Supplier<T> instanceSupplier) {
+      this.klass = klass;
+      this.instance = instanceSupplier;
+    }
 
-    Method operation = getOperation(operationName, parameters.keySet(), headerParameters.keySet());
 
-    Map<String, String> combinedParameters = new HashMap<>();
-    combinedParameters.putAll(parameters);
-    combinedParameters.putAll(headerParameters);
+    /**
+     * Invoke the web service operation and return its return value
+     *
+     * <p>
+     * The return value conforms to that stated for {@link Method#invoke(Object, Object...)},
+     * e.g., will be null if the underlying return type is void; will be boxed if the underlying
+     * return type is primitive.
+     *
+     * @param operationName    Name of the operation
+     * @param parameters       Parameters
+     * @param headerParameters Headers
+     * @return the return value of the operation
+     */
+    Object invokeOperation(String operationName, Map<String, String> parameters, Map<String, String> headerParameters) {
 
-    Object[] operationArgs = Arrays.stream(operation.getParameters())
+      Method operation = getOperation(operationName, parameters.keySet(), headerParameters.keySet());
+
+      Map<String, String> combinedParameters = new HashMap<>();
+      combinedParameters.putAll(parameters);
+      combinedParameters.putAll(headerParameters);
+
+      Object[] operationArgs = Arrays.stream(operation.getParameters())
         .map(operationParameter -> parameterToType(operationParameter, combinedParameters))
         .toArray();
 
-    try {
-      return operation.invoke(instance.get(), operationArgs);
-    } catch (InvocationTargetException e) {
+      try {
+        return operation.invoke(instance.get(), operationArgs);
+      } catch (InvocationTargetException e) {
 
-      throw Optional.ofNullable(Mappers.INSTANCE.getExceptionMapper())
-        .flatMap(mapper -> mapper.mapThrowable(e.getTargetException(), Mappers.INSTANCE.getObjectMapper()))
-        .orElse(new InternalServerErrorException());
+        throw Optional.ofNullable(INSTANCE.getExceptionMapper())
+          .flatMap(mapper -> mapper.mapThrowable(e.getTargetException(), INSTANCE.getObjectMapper()))
+          .orElse(new InternalServerErrorException());
 
-    } catch (IllegalAccessException e) {
-      /*
-       * We've already thoroughly checked that the method was valid and accessible, so this shouldn't happen.
-       * If it does, it's something more nefarious than a 404
-       */
-      throw new InternalServerErrorException();
+      } catch (IllegalAccessException e) {
+        /*
+         * We've already thoroughly checked that the method was valid and accessible, so this shouldn't happen.
+         * If it does, it's something more nefarious than a 404
+         */
+        throw new InternalServerErrorException();
+      }
     }
-  }
 
 
-  /*
-   * Get the method for the requested operation
-   */
-  private Method getOperation(String operationName, Set<String> parameterNames, Set<String> headerParameterNames) {
+    /*
+     * Get the method for the requested operation
+     */
+    private Method getOperation(String operationName, Set<String> parameterNames, Set<String> headerParameterNames) {
 
-    Method[] declaredMethods = klass.getDeclaredMethods();
-    List<Method> methods = Arrays.stream(declaredMethods)
+      Method[] declaredMethods = klass.getDeclaredMethods();
+      List<Method> methods = Arrays.stream(declaredMethods)
         .filter(method -> method.getName().equals(operationName)) // find a method with the same name as the requested operation
         .filter(method -> matchesParameters(method, parameterNames, headerParameterNames)) // Check that the method parameters matched those passed
         .filter(this::methodIsWebMethod) // Check that the method is actually exposed via web services
         .collect(Collectors.toList());
 
-    if (methods.isEmpty()) {
-      throw new NotFoundException();
+      if (methods.isEmpty()) {
+        throw new NotFoundException();
+      }
+
+      if (methods.size() > 1) {
+        /*
+         * This seems appropriate: the request has insufficient information for us to determine what method the user
+         * is trying to call. This might because there are two methods with the same name and same-named arguments
+         * but that is simply unfortunate (and somewhat unlikely)
+         */
+        throw new BadRequestException("Unable to distinguish methods");
+      }
+
+      return methods.get(0);
     }
 
-    if (methods.size() > 1) {
-      /*
-       * This seems appropriate: the request has insufficient information for us to determine what method the user
-       * is trying to call. This might because there are two methods with the same name and same-named arguments
-       * but that is simply unfortunate (and somewhat unlikely)
-       */
-      throw new BadRequestException("Unable to distinguish methods");
+
+    /*
+     * Check the method is public and not specifically excluded from web services.
+     * This should be sufficient to ensure we only serve methods actually provided
+     * by the web services
+     */
+    private boolean methodIsWebMethod(Method method) {
+
+      // only public methods can be published
+      if (!Modifier.isPublic(method.getModifiers())) {
+        return false;
+      }
+
+      // check if WebMethod annotation exists and exclude is true, if so then not a web method
+      WebMethod webMethod = method.getAnnotation(WebMethod.class);
+      return webMethod == null || !webMethod.exclude();
     }
 
-    return methods.get(0);
-  }
 
+    /*
+     * Check that the given method has all and only the parameters passed in
+     */
+    private boolean matchesParameters(Method method, Set<String> parameterNames, Set<String> headerParameterNames) {
 
-  /*
-   * Check the method is public and not specifically excluded from web services.
-   * This should be sufficient to ensure we only serve methods actually provided
-   * by the web services
-   */
-  private boolean methodIsWebMethod(Method method) {
+      Parameter[] methodParameters = method.getParameters();
 
-    // only public methods can be published
-    if (!Modifier.isPublic(method.getModifiers())) {
-      return false;
-    }
-
-    // check if WebMethod annotation exists and exclude is true, if so then not a web method
-    WebMethod webMethod = method.getAnnotation(WebMethod.class);
-    return webMethod == null || !webMethod.exclude();
-  }
-
-
-  /*
-   * Check that the given method has all and only the parameters passed in
-   */
-  private boolean matchesParameters(Method method, Set<String> parameterNames, Set<String> headerParameterNames) {
-
-    Parameter[] methodParameters = method.getParameters();
-
-    // Check that the header parameters are correctly annotated with @WebParam(header = true)
-    Set<String> headerParameters = Arrays.stream(methodParameters)
+      // Check that the header parameters are correctly annotated with @WebParam(header = true)
+      Set<String> headerParameters = Arrays.stream(methodParameters)
         .filter(parameter -> parameter.getAnnotation(WebParam.class) != null)
         .filter(parameter -> parameter.getAnnotation(WebParam.class).header()) // Filter only the parameters where header = true
         .map(parameter -> parameter.getAnnotation(WebParam.class).name())
         .collect(Collectors.toSet());
 
-    // If not correctly annotated, throw a bad request exception
-    if (!headerParameters.containsAll(headerParameterNames)) {
-      throw new BadRequestException(
-        Response.status(Response.Status.BAD_REQUEST)
-        .entity(headerParameterNames)
-        .build());
-    }
+      // If not correctly annotated, throw a bad request exception
+      if (!headerParameters.containsAll(headerParameterNames)) {
+        throw new BadRequestException(
+          Response.status(Response.Status.BAD_REQUEST)
+            .entity(headerParameterNames)
+            .build());
+      }
 
-    Set<String> combinedParameterNames = new HashSet<>(); // Combine the method and header parameters
-    combinedParameterNames.addAll(headerParameterNames);
-    combinedParameterNames.addAll(parameterNames);
+      Set<String> combinedParameterNames = new HashSet<>(); // Combine the method and header parameters
+      combinedParameterNames.addAll(headerParameterNames);
+      combinedParameterNames.addAll(parameterNames);
 
-    Set<String> allParameters = Arrays.stream(methodParameters)
+      Set<String> allParameters = Arrays.stream(methodParameters)
         .filter(parameter -> parameter.getAnnotation(WebParam.class) != null)
         .map(parameter -> parameter.getAnnotation(WebParam.class).name())
         .collect(Collectors.toSet());
 
-    return allParameters.containsAll(combinedParameterNames) && allParameters.size() == combinedParameterNames.size();
+      return allParameters.containsAll(combinedParameterNames) && allParameters.size() == combinedParameterNames.size();
+    }
+
+
+    /*
+     * Map any primitives, strings or JSON to actual types.
+     */
+    private Object parameterToType(Parameter operationParameter, Map<String, String> parameters) {
+
+      String argumentAsString = parameters.get(operationParameter.getAnnotation(WebParam.class).name());
+
+      if (argumentAsString == null || argumentAsString.trim().isEmpty() || argumentAsString.equals("null")) {
+        return null;
+      }
+
+      // Try type converter. This should work for common serialisations in query parameters
+      Object object = typeConverter.convertValue(argumentAsString, operationParameter.getType());
+
+      if (object != null) {
+        return object;
+      }
+
+      /*
+       * The only other option is JSON. Try the mapper. If it doesn't work, then the request is
+       *presumably malformed
+       */
+      JavaType type = INSTANCE.getObjectMapper().constructType(operationParameter.getParameterizedType());
+
+      try {
+        return INSTANCE.getObjectMapper().readValue(argumentAsString, type);
+      } catch (IOException e) {
+        e.printStackTrace();
+        throw new BadRequestException();
+      }
+    }
   }
 
-
-  /*
-   * Map any primitives, strings or JSON to actual types.
-   */
-  private Object parameterToType(Parameter operationParameter, Map<String, String> parameters) {
-
-    String argumentAsString = parameters.get(operationParameter.getAnnotation(WebParam.class).name());
-
-    if (argumentAsString == null || argumentAsString.trim().isEmpty() || argumentAsString.equals("null")) {
-      return null;
-    }
-
-    Class<?> type = operationParameter.getType();
-
-    Object object = typeConverter.convertValue(argumentAsString, type);
-
-    if (object != null) {
-      return object;
-    }
-
-    try {
-      return Mappers.INSTANCE.getObjectMapper().readValue(argumentAsString, operationParameter.getType());
-    } catch (IOException e) {
-      e.printStackTrace();
-      throw new BadRequestException();
-    }
-  }
-}

--- a/src/test/java/org/alfasoftware/soapstone/TestTypeConverter.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestTypeConverter.java
@@ -14,7 +14,25 @@
  */
 package org.alfasoftware.soapstone;
 
-import com.google.common.collect.Lists;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.InvocationTargetException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Currency;
+import java.util.Date;
+import java.util.Locale;
+
 import org.alfasoftware.soapstone.testsupport.DummyCustomClass;
 import org.alfasoftware.soapstone.testsupport.DummyGetInstanceClass;
 import org.alfasoftware.soapstone.testsupport.DummyParseableClass;
@@ -27,24 +45,7 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
-import java.lang.reflect.InvocationTargetException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Currency;
-import java.util.Date;
-import java.util.Locale;
-
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import com.google.common.collect.Lists;
 
 
 /**
@@ -126,9 +127,9 @@ public class TestTypeConverter {
   public void testCommaSeparatedParsing() {
     assertEquals("Simple number", 42, ukConverter.convertValue("42", Integer.class).intValue());
 
-    assertEquals("Commas-separated number", 12345.67, ukConverter.convertValue("12,345.67", Double.class).doubleValue(), 0.001);
+    assertEquals("Commas-separated number", 12345.67, ukConverter.convertValue("12,345.67", Double.class), 0.001);
 
-    assertEquals("Currency", 3999.99, ukConverter.convertValue('\u00a3' + "3,999.99", Double.class).doubleValue(), 0.001);
+    assertEquals("Currency", 3999.99, ukConverter.convertValue('\u00a3' + "3,999.99", Double.class), 0.001);
   }
 
 
@@ -198,7 +199,6 @@ public class TestTypeConverter {
 
   /**
    * Test date parsing in multiple locales.
-   * @throws ParseException
    */
   @Test
   public void testDates() throws ParseException {
@@ -222,11 +222,10 @@ public class TestTypeConverter {
 
   /**
    * Tests parsing LocalDates in several ways.
-   * @throws ParseException if convert goes wrong.
    */
   @Test
   public void testLocalDates() {
-    assertDates(LocalDate.class, new LocalDate(1977, 12, 4), new LocalDate(2014, 02, 28));
+    assertDates(LocalDate.class, new LocalDate(1977, 12, 4), new LocalDate(2014, 2, 28));
 
     final LocalDate farFuture = new LocalDate(1999, 12, 31);
     assertEquals("UK short date with 4-digit year in far future", farFuture, ukConverter.convertValue("31/12/1999", LocalDate.class));
@@ -281,7 +280,6 @@ public class TestTypeConverter {
 
   /**
    * Test for parsing {@link LocalTime} objects correctly
-   * @throws ParseException
    */
   @Test
   public void testLocalTimesWithWhitespace() throws ParseException {
@@ -332,7 +330,6 @@ public class TestTypeConverter {
 
   /**
    * Test for parsing {@link LocalTime} objects correctly
-   * @throws ParseException
    */
   @Test
   public void testLocalTimes() throws ParseException {
@@ -363,7 +360,6 @@ public class TestTypeConverter {
 
   /**
    * Test for parsing {@link LocalTime} objects correctly
-   * @throws ParseException
    */
   @Test
   public void testISOLocalTimes() throws ParseException {
@@ -385,8 +381,11 @@ public class TestTypeConverter {
   }
 
 
+  /**
+   * Test parsing of invalid time
+   */
   @Test(expected=ParseException.class)
-  public void testconvertTimeFailure() throws ParseException {
+  public void testConvertTimeFailure() throws ParseException {
     ukConverter.convert("invalid", LocalTime.class);
   }
 
@@ -404,8 +403,6 @@ public class TestTypeConverter {
 
   /**
    * Test Locale conversion with language and country
-   *
-   * @throws ParseException
    */
   @Test
   public void testLocaleLangCountry() throws ParseException {
@@ -416,8 +413,6 @@ public class TestTypeConverter {
 
   /**
    * Test Locale conversion with language
-   *
-   * @throws ParseException
    */
   @Test
   public void testLocaleLang() throws ParseException {
@@ -428,8 +423,6 @@ public class TestTypeConverter {
 
   /**
    * Test Locale conversion with language, country and code
-   *
-   * @throws ParseException
    */
   @Test
   public void testLocaleLangCountryCode() throws ParseException {
@@ -440,8 +433,6 @@ public class TestTypeConverter {
 
   /**
    * Test Locale conversion wrong format case
-   *
-   * @throws ParseException
    */
   @Test(expected = ParseException.class)
   public void testLocaleWrongFormat() throws ParseException {
@@ -518,7 +509,7 @@ public class TestTypeConverter {
     assertEquals("Integer", 12, (int)ukConverter.convertValue("  12", Integer.TYPE));
     assertEquals("Negative integer", -12, (int)ukConverter.convertValue("-12", Integer.TYPE));
     assertEquals("Double", 12.45, ukConverter.convertValue("  12.45", Double.TYPE), 0.0001);
-    assertEquals("Boolean", true, (boolean)ukConverter.convertValue("  true", Boolean.TYPE));
+    assertTrue("Boolean", ukConverter.convertValue("  true", Boolean.TYPE));
     assertEquals("Character", ' ', (char)ukConverter.convertValue(32, Character.TYPE));
     assertEquals("Byte from number", 32, (byte)ukConverter.convertValue(32, Byte.TYPE));
     assertEquals("Byte from string", 32, (byte)ukConverter.convertValue(" ", Byte.TYPE));
@@ -561,8 +552,6 @@ public class TestTypeConverter {
 
   /**
    * The {@link NumberFormatException} should be always caught and re-thrown as {@link ParseException}
-   *
-   * @throws ParseException
    */
   @Test(expected = ParseException.class)
   public void invalidCharsInBigIntegerValueShouldCauseParseException() throws ParseException {
@@ -580,7 +569,7 @@ public class TestTypeConverter {
     assertEquals("Empty string converted to default long", 0L, (long)ukConverter.convertValue("", long.class));
     assertEquals("Empty string converted to default float", 0f, ukConverter.convertValue("", float.class), 0.0001);
     assertEquals("Empty string converted to default double", 0d, ukConverter.convertValue("", double.class), 0.0001);
-    assertEquals("Empty string converted to default boolean", false, (boolean)ukConverter.convertValue("", boolean.class));
+    assertFalse("Empty string converted to default boolean", ukConverter.convertValue("", boolean.class));
   }
 
 
@@ -745,10 +734,9 @@ public class TestTypeConverter {
   /**
    * Check that the {@link TypeConverter#convert(Object, Class)} method
    * which throws an exception does so.
-   * @throws java.text.ParseException
    */
   @Test
-  public void testExceptionThrowingMethod() throws java.text.ParseException {
+  public void testExceptionThrowingMethod() throws ParseException {
     assertNull("Empty string to null", ukConverter.convert("", Integer.class));
     try {
       ukConverter.convert("foo", Integer.class);
@@ -827,25 +815,25 @@ public class TestTypeConverter {
   /**
    * @param dateType The type of date we can convert to / from.
    * @param fourthDecemberSeventySeven A representation of fourth of December 1977.
-   * @param twentyeighthFebTwentyFourteen A representation of 28th of February 2014.
+   * @param twentyEighthFebTwentyFourteen A representation of 28th of February 2014.
    */
-  private <T> void assertDates(Class<T> dateType, T fourthDecemberSeventySeven, T twentyeighthFebTwentyFourteen) {
-    assertEquals("UK short date after 2010", twentyeighthFebTwentyFourteen, ukConverter.convertValue("28/02/14", dateType));
-    assertEquals("UK short date after 2010 without leading zero", twentyeighthFebTwentyFourteen, ukConverter.convertValue("28/2/14", dateType));
-    assertEquals("UK short date after 2010 without leading zero", twentyeighthFebTwentyFourteen, ukConverter.convertValue("28/2/2014", dateType));
-    assertEquals("ISO-8601 date indepedent of UK locale", twentyeighthFebTwentyFourteen, ukConverter.convertValue(twentyeighthFebTwentyFourteen, dateType));
+  private <T> void assertDates(Class<T> dateType, T fourthDecemberSeventySeven, T twentyEighthFebTwentyFourteen) {
+    assertEquals("UK short date after 2010", twentyEighthFebTwentyFourteen, ukConverter.convertValue("28/02/14", dateType));
+    assertEquals("UK short date after 2010 without leading zero", twentyEighthFebTwentyFourteen, ukConverter.convertValue("28/2/14", dateType));
+    assertEquals("UK short date after 2010 without leading zero", twentyEighthFebTwentyFourteen, ukConverter.convertValue("28/2/2014", dateType));
+    assertEquals("ISO-8601 date independent of UK locale", twentyEighthFebTwentyFourteen, ukConverter.convertValue(twentyEighthFebTwentyFourteen, dateType));
 
     assertEquals("UK short date", fourthDecemberSeventySeven, ukConverter.convertValue("04/12/77", dateType));
     assertEquals("UK short date without leading zero", fourthDecemberSeventySeven, ukConverter.convertValue("4/12/77", dateType));
     assertEquals("UK short date with 4-digit year", fourthDecemberSeventySeven, ukConverter.convertValue("4/12/1977", dateType));
-    assertEquals("ISO-8601 date indepedent of UK locale", fourthDecemberSeventySeven, ukConverter.convertValue(fourthDecemberSeventySeven, dateType));
+    assertEquals("ISO-8601 date independent of UK locale", fourthDecemberSeventySeven, ukConverter.convertValue(fourthDecemberSeventySeven, dateType));
 
     assertNull("Pushing forward dates", ukConverter.convertValue("33/3/08", dateType));
 
     TypeConverter usConverter = new TypeConverter(Locale.US);
-    assertEquals("US short date", twentyeighthFebTwentyFourteen, usConverter.convertValue("02/28/14", dateType));
+    assertEquals("US short date", twentyEighthFebTwentyFourteen, usConverter.convertValue("02/28/14", dateType));
     assertEquals("US short date", fourthDecemberSeventySeven, usConverter.convertValue("12/04/77", dateType));
-    assertEquals("ISO-8601 date indepedent of US locale", fourthDecemberSeventySeven, usConverter.convertValue(fourthDecemberSeventySeven, dateType));
+    assertEquals("ISO-8601 date independent of US locale", fourthDecemberSeventySeven, usConverter.convertValue(fourthDecemberSeventySeven, dateType));
 
     assertNull("Invalid date string", usConverter.convertValue("wibble", dateType));
 
@@ -869,32 +857,29 @@ public class TestTypeConverter {
   /**
    * @param dateType The type of date we can convert to / from.
    * @param fourthDecemberSeventySeven A representation of fourth of December 1977.
-   * @param twentyeighthFebTwentyFourteen A representation of 28th of February 2014.
+   * @param twentyEighthFebTwentyFourteen A representation of 28th of February 2014.
    */
-  private <T> void assertDatesWithWhitespace(Class<T> dateType, T fourthDecemberSeventySeven, T twentyeighthFebTwentyFourteen) {
-    assertEquals("UK short date after 2010", twentyeighthFebTwentyFourteen, ukConverter.convertValue("   28/02/14   ", dateType));
-    assertEquals("UK short date after 2010 without leading zero", twentyeighthFebTwentyFourteen, ukConverter.convertValue("   28/2/14   ", dateType));
-    assertEquals("UK short date after 2010 without leading zero", twentyeighthFebTwentyFourteen, ukConverter.convertValue("   28/2/2014   ", dateType));
-    assertEquals("ISO-8601 date indepedent of UK locale", twentyeighthFebTwentyFourteen, ukConverter.convertValue(twentyeighthFebTwentyFourteen, dateType));
+  private <T> void assertDatesWithWhitespace(Class<T> dateType, T fourthDecemberSeventySeven, T twentyEighthFebTwentyFourteen) {
+    assertEquals("UK short date after 2010", twentyEighthFebTwentyFourteen, ukConverter.convertValue("   28/02/14   ", dateType));
+    assertEquals("UK short date after 2010 without leading zero", twentyEighthFebTwentyFourteen, ukConverter.convertValue("   28/2/14   ", dateType));
+    assertEquals("UK short date after 2010 without leading zero", twentyEighthFebTwentyFourteen, ukConverter.convertValue("   28/2/2014   ", dateType));
+    assertEquals("ISO-8601 date independent of UK locale", twentyEighthFebTwentyFourteen, ukConverter.convertValue(twentyEighthFebTwentyFourteen, dateType));
 
     assertEquals("UK short date", fourthDecemberSeventySeven, ukConverter.convertValue("   04/12/77   ", dateType));
     assertEquals("UK short date without leading zero", fourthDecemberSeventySeven, ukConverter.convertValue("   4/12/77   ", dateType));
     assertEquals("UK short date with 4-digit year", fourthDecemberSeventySeven, ukConverter.convertValue("   4/12/1977   ", dateType));
-    assertEquals("ISO-8601 date indepedent of UK locale", fourthDecemberSeventySeven, ukConverter.convertValue(fourthDecemberSeventySeven, dateType));
+    assertEquals("ISO-8601 date independent of UK locale", fourthDecemberSeventySeven, ukConverter.convertValue(fourthDecemberSeventySeven, dateType));
 
     TypeConverter usConverter = new TypeConverter(Locale.US);
-    assertEquals("US short date", twentyeighthFebTwentyFourteen, usConverter.convertValue("   02/28/14   ", dateType));
+    assertEquals("US short date", twentyEighthFebTwentyFourteen, usConverter.convertValue("   02/28/14   ", dateType));
     assertEquals("US short date", fourthDecemberSeventySeven, usConverter.convertValue("   12/04/77   ", dateType));
-    assertEquals("ISO-8601 date indepedent of US locale", fourthDecemberSeventySeven, usConverter.convertValue(fourthDecemberSeventySeven, dateType));
+    assertEquals("ISO-8601 date independent of US locale", fourthDecemberSeventySeven, usConverter.convertValue(fourthDecemberSeventySeven, dateType));
   }
 
 
   /**
    * Convenience method for checking that a number of different alphanumeric
    * sequences cannot be parsed to integers.
-   *
-   * @param input
-   * @param errorIndex
    */
   private void checkFailingNumber(String input, int errorIndex) {
     try {
@@ -910,9 +895,6 @@ public class TestTypeConverter {
   /**
    * Convenience method for checking that a number of different alphanumeric
    * sequences cannot be parsed to integers.
-   *
-   * @param input
-   * @param errorIndex
    */
   private void checkFailingNumber(TypeConverter typeConverter, String input, int errorIndex) {
     try {
@@ -925,11 +907,11 @@ public class TestTypeConverter {
   }
 
 
-  public static class Animal {
+  static class Animal {
 
   }
 
-  public static class Dog extends Animal {
+  static class Dog extends Animal {
 
   }
 

--- a/src/test/java/org/alfasoftware/soapstone/TestWebServiceClass.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestWebServiceClass.java
@@ -1,47 +1,52 @@
-/* Copyright 2019 Alfa Financial Software
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.alfasoftware.soapstone;
+  /* Copyright 2019 Alfa Financial Software
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *    http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+  package org.alfasoftware.soapstone;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.alfasoftware.soapstone.testsupport.CustomParameterClass;
-import org.alfasoftware.soapstone.testsupport.MockedClassForTestingJsonHttp;
-import org.joda.time.LocalDate;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+  import static org.junit.Assert.assertEquals;
+  import static org.mockito.Matchers.any;
+  import static org.mockito.Matchers.eq;
+  import static org.mockito.Mockito.mock;
+  import static org.mockito.Mockito.verify;
+  import static org.mockito.Mockito.when;
 
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.WebApplicationException;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+  import java.io.IOException;
+  import java.lang.reflect.Type;
+  import java.util.HashMap;
+  import java.util.List;
+  import java.util.Map;
+  import java.util.Optional;
 
-import static org.alfasoftware.soapstone.WebServiceClass.forClass;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+  import javax.ws.rs.BadRequestException;
+  import javax.ws.rs.InternalServerErrorException;
+  import javax.ws.rs.NotFoundException;
+  import javax.ws.rs.WebApplicationException;
 
-/**
+  import org.alfasoftware.soapstone.testsupport.CustomParameterClass;
+  import org.alfasoftware.soapstone.testsupport.MockedClassForTestingJsonHttp;
+  import org.glassfish.hk2.api.TypeLiteral;
+  import org.junit.Before;
+  import org.junit.Rule;
+  import org.junit.Test;
+  import org.junit.rules.ExpectedException;
+  import org.mockito.Mock;
+  import org.mockito.MockitoAnnotations;
+
+  import com.fasterxml.jackson.databind.JavaType;
+  import com.fasterxml.jackson.databind.ObjectMapper;
+
+  /**
  * Tests for the {@link WebServiceClass} class.
  *
  * @author Copyright (c) Alfa Financial Software 2019
@@ -52,7 +57,8 @@ public class TestWebServiceClass {
   @Mock private WebApplicationException webApplicationException;
   @Mock private ObjectMapper objectMapper;
 
-  @Rule public final ExpectedException exception = ExpectedException.none();
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
 
   private static final String OPERATION_NAME = "mockedMethod";
   private static final String EXPECTED_RESPONSE = "The method has been invoked!";
@@ -69,7 +75,7 @@ public class TestWebServiceClass {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
 
-    webServiceClass = forClass(MockedClassForTestingJsonHttp.class, MockedClassForTestingJsonHttp::new);
+    webServiceClass = WebServiceClass.forClass(MockedClassForTestingJsonHttp.class, MockedClassForTestingJsonHttp::new);
 
     Mappers.INSTANCE.setObjectMapper(objectMapper);
     Mappers.INSTANCE.setExceptionMapper(exceptionMapper);
@@ -289,24 +295,6 @@ public class TestWebServiceClass {
 
   /**
    * Tests that the {@link WebServiceClass#invokeOperation(String, Map, Map)} method correctly maps
-   * parameters for methods that require a LocalDate.
-   */
-  @Test
-  public void testParameterToTypeParameterLocalDate() {
-
-    // Given
-    nonHeaderParameters.put("localDateParameter", "01/02/2019");
-
-    // When
-    Object parameter = webServiceClass.invokeOperation("mockedMethodWithLocalDateArg", nonHeaderParameters, headerParameters);
-
-    // Then
-    assertEquals("Parameter type is incorrect", LocalDate.class, parameter.getClass());
-  }
-
-
-  /**
-   * Tests that the {@link WebServiceClass#invokeOperation(String, Map, Map)} method correctly maps
    * parameters for methods that require a custom class: here, {@link CustomParameterClass}.
    */
   @Test
@@ -316,11 +304,40 @@ public class TestWebServiceClass {
     String argumentAsString = "{\"fieldOne\":\"VALUE\",\"fieldTwo\":1}";
     nonHeaderParameters.put("customParameter", argumentAsString);
 
+    JavaType javaType = mock(JavaType.class);
+    Type type = CustomParameterClass.class;
+    when(objectMapper.constructType(type)).thenReturn(javaType);
+
     // When
     webServiceClass.invokeOperation("mockedMethodWithCustomParameterClassArg", nonHeaderParameters, headerParameters);
 
     // Then
-    verify(objectMapper).readValue(argumentAsString, CustomParameterClass.class);
+    verify(objectMapper).constructType(type);
+    verify(objectMapper).readValue(argumentAsString, javaType);
+  }
+
+
+  /**
+   * Tests that the {@link WebServiceClass#invokeOperation(String, Map, Map)} method correctly maps
+   * parameters for methods that require a list of a custom class: here, {@link CustomParameterClass}.
+   */
+  @Test
+  public void testParameterToListOfTypeParameterCustomClass() throws IOException {
+
+    // Given
+    String argumentAsString = "[ {\"fieldOne\":\"VALUE\",\"fieldTwo\":1}, {\"fieldOne\":\"ANOTHER_VALUE\",\"fieldTwo\":2} ]";
+    nonHeaderParameters.put("customParameters", argumentAsString);
+
+    JavaType javaType = mock(JavaType.class);
+    Type type = new TypeLiteral<List<CustomParameterClass>>(){}.getType();
+    when(objectMapper.constructType(type)).thenReturn(javaType);
+
+    // When
+    webServiceClass.invokeOperation("mockedMethodWithListOfCustomParameterClassArg", nonHeaderParameters, headerParameters);
+
+    // Then
+    verify(objectMapper).constructType(type);
+    verify(objectMapper).readValue(argumentAsString, javaType);
   }
 }
 

--- a/src/test/java/org/alfasoftware/soapstone/TestWebServiceClass.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestWebServiceClass.java
@@ -36,6 +36,7 @@
   import org.alfasoftware.soapstone.testsupport.CustomParameterClass;
   import org.alfasoftware.soapstone.testsupport.MockedClassForTestingJsonHttp;
   import org.glassfish.hk2.api.TypeLiteral;
+  import org.joda.time.LocalDate;
   import org.junit.Before;
   import org.junit.Rule;
   import org.junit.Test;
@@ -109,6 +110,23 @@ public class TestWebServiceClass {
     // Given
     nonHeaderParameters.put("parameter", "parameterValue");
     headerParameters.put("headerParameter", "headerParameterValue");
+
+    // When
+    Object object = webServiceClass.invokeOperation("methodWithCorrectlyAnnotatedHeaderParam", nonHeaderParameters, headerParameters);
+
+    // Then
+    assertEquals("The method was not invoked", EXPECTED_RESPONSE, object.toString());
+  }
+
+
+  /**
+   * Test that headers are treated as optional. An invocation should not fail if there are missing header parameters.
+   */
+  @Test
+  public void testInvokeOperationWhenHeaderParamsAbsent() {
+
+    // Given
+    nonHeaderParameters.put("parameter", "parameterValue");
 
     // When
     Object object = webServiceClass.invokeOperation("methodWithCorrectlyAnnotatedHeaderParam", nonHeaderParameters, headerParameters);
@@ -290,6 +308,24 @@ public class TestWebServiceClass {
 
     // Then
     assertEquals("Parameter type is incorrect", Integer.class, parameter.getClass());
+  }
+
+
+  /**
+   * Tests that the {@link WebServiceClass#invokeOperation(String, Map, Map)} method correctly maps
+   * parameters for methods that require a LocalDate.
+   */
+  @Test
+  public void testParameterToTypeParameterLocalDate() {
+
+    // Given
+    nonHeaderParameters.put("localDateParameter", "01/02/2019");
+
+    // When
+    Object parameter = webServiceClass.invokeOperation("mockedMethodWithLocalDateArg", nonHeaderParameters, headerParameters);
+
+    // Then
+    assertEquals("Parameter type is incorrect", LocalDate.class, parameter.getClass());
   }
 
 

--- a/src/test/java/org/alfasoftware/soapstone/testsupport/CustomParameterClass.java
+++ b/src/test/java/org/alfasoftware/soapstone/testsupport/CustomParameterClass.java
@@ -20,6 +20,7 @@ package org.alfasoftware.soapstone.testsupport;
  *
  * @author Copyright (c) Alfa Financial Software 2019
  */
+@SuppressWarnings("unused")
 public class CustomParameterClass {
 
   private final String fieldOne;

--- a/src/test/java/org/alfasoftware/soapstone/testsupport/DummyCustomClass.java
+++ b/src/test/java/org/alfasoftware/soapstone/testsupport/DummyCustomClass.java
@@ -18,10 +18,11 @@ package org.alfasoftware.soapstone.testsupport;
 import java.math.BigDecimal;
 
 /**
- * Dummy class to test the valueOf TypeConvertor conversion
+ * Dummy class to test the valueOf TypeConverter conversion
  *
  * @author Copyright (c) Alfa Financial Software 2019
  */
+@SuppressWarnings("unused")
 public class DummyCustomClass extends BigDecimal {
 
  public DummyCustomClass(String s) {

--- a/src/test/java/org/alfasoftware/soapstone/testsupport/DummyGetInstanceClass.java
+++ b/src/test/java/org/alfasoftware/soapstone/testsupport/DummyGetInstanceClass.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
  *
  * @author Copyright (c) Alfa Financial Software 2019
  */
+@SuppressWarnings("unused")
 public class DummyGetInstanceClass extends BigDecimal {
 
  public DummyGetInstanceClass(String s) {

--- a/src/test/java/org/alfasoftware/soapstone/testsupport/DummyParseableClass.java
+++ b/src/test/java/org/alfasoftware/soapstone/testsupport/DummyParseableClass.java
@@ -17,10 +17,11 @@ package org.alfasoftware.soapstone.testsupport;
 import java.math.BigDecimal;
 
 /**
- * Dummy class to test the parse OgnlTypeConvertor conversion.
+ * Dummy class to test the parse OgnlTypeConverter conversion.
  *
  * @author Copyright (c) Alfa Financial Software 2019
  */
+@SuppressWarnings("unused")
 public class DummyParseableClass extends BigDecimal {
 
   /**

--- a/src/test/java/org/alfasoftware/soapstone/testsupport/MockedClassForTestingJsonHttp.java
+++ b/src/test/java/org/alfasoftware/soapstone/testsupport/MockedClassForTestingJsonHttp.java
@@ -15,12 +15,14 @@
 package org.alfasoftware.soapstone.testsupport;
 
 
-import org.alfasoftware.soapstone.WebServiceClass;
-import org.joda.time.LocalDate;
+import java.util.List;
 
 import javax.jws.WebMethod;
 import javax.jws.WebParam;
 import javax.ws.rs.WebApplicationException;
+
+import org.alfasoftware.soapstone.WebServiceClass;
+import org.joda.time.LocalDate;
 
 
 /**
@@ -28,16 +30,15 @@ import javax.ws.rs.WebApplicationException;
  *
  * @author Copyright (c) Alfa Financial Software 2019
  */
+@SuppressWarnings("unused")
 public class MockedClassForTestingJsonHttp {
-
-  private final String parameter = "";
 
 
   /**
    * A simple mocked method for testing.
    */
   @WebMethod
-  public String mockedMethod(@WebParam(name="parameter") String parameter) {
+  public String mockedMethod(@WebParam(name = "parameter") String parameter) {
 
     if (parameter.equals("throwWebApplicationException")) {
       throw new WebApplicationException();
@@ -50,7 +51,7 @@ public class MockedClassForTestingJsonHttp {
    * Simple mocked method with a string parameter.
    */
   @WebMethod
-  public String mockedMethodWithStringArg(@WebParam(name="stringParameter") String stringParameter) {
+  public String mockedMethodWithStringArg(@WebParam(name = "stringParameter") String stringParameter) {
     return stringParameter;
   }
 
@@ -59,7 +60,7 @@ public class MockedClassForTestingJsonHttp {
    * Simple mocked method with a boolean parameter
    */
   @WebMethod
-  public boolean mockedMethodWithBooleanArg(@WebParam(name="booleanParameter") boolean booleanParameter) {
+  public boolean mockedMethodWithBooleanArg(@WebParam(name = "booleanParameter") boolean booleanParameter) {
     return booleanParameter;
   }
 
@@ -68,7 +69,7 @@ public class MockedClassForTestingJsonHttp {
    * Simple mocked method with a int parameter
    */
   @WebMethod
-  public int mockedMethodWithIntArg(@WebParam(name="intParameter") int intParameter) {
+  public int mockedMethodWithIntArg(@WebParam(name = "intParameter") int intParameter) {
     return intParameter;
   }
 
@@ -77,7 +78,7 @@ public class MockedClassForTestingJsonHttp {
    * Simple mocked method with a {@link LocalDate} parameter
    */
   @WebMethod
-  public LocalDate mockedMethodWithLocalDateArg(@WebParam(name="localDateParameter") LocalDate localDateParameter) {
+  public LocalDate mockedMethodWithLocalDateArg(@WebParam(name = "localDateParameter") LocalDate localDateParameter) {
     return localDateParameter;
   }
 
@@ -86,8 +87,19 @@ public class MockedClassForTestingJsonHttp {
    * Simple mocked method with a {@link CustomParameterClass} parameter
    */
   @WebMethod
-  public CustomParameterClass mockedMethodWithCustomParameterClassArg(@WebParam(name="customParameter") CustomParameterClass customParameter) {
+  public CustomParameterClass mockedMethodWithCustomParameterClassArg(
+    @WebParam(name = "customParameter") CustomParameterClass customParameter) {
     return customParameter;
+  }
+
+
+  /**
+   * Simple mocked method with list of {@link CustomParameterClass} parameter
+   */
+  @WebMethod
+  public List<CustomParameterClass> mockedMethodWithListOfCustomParameterClassArg(
+    @WebParam(name = "customParameters") List<CustomParameterClass> customParameters) {
+    return customParameters;
   }
 
 
@@ -95,7 +107,7 @@ public class MockedClassForTestingJsonHttp {
    * An overloaded method for testing whether similar methods can be distinguished.
    */
   @WebMethod
-  public String overloadedMethod(@WebParam(name="parameter") String parameter) {
+  public String overloadedMethod(@WebParam(name = "parameter") String parameter) {
     return parameter;
   }
 
@@ -104,7 +116,7 @@ public class MockedClassForTestingJsonHttp {
    * An overloaded method for testing whether similar methods can be distinguished.
    */
   @WebMethod
-  public String overloadedMethod(@WebParam(name="parameter") String parameter, String parameter2) {
+  public String overloadedMethod(@WebParam(name = "parameter") String parameter, String parameter2) {
     return parameter + parameter2;
   }
 
@@ -113,8 +125,7 @@ public class MockedClassForTestingJsonHttp {
    * A private method for testing whether private methods can be published.
    */
   @WebMethod
-  @SuppressWarnings("unused")
-  private String privateMethod(@WebParam(name="parameter") String parameter) {
+  private String privateMethod(@WebParam(name = "parameter") String parameter) {
     return parameter;
   }
 
@@ -122,8 +133,8 @@ public class MockedClassForTestingJsonHttp {
   /**
    * A method for testing when the WebMethod annotation has been set to exclude = true.
    */
-  @WebMethod(exclude=true)
-  public String excludedMethod(@WebParam(name="parameter") String parameter) {
+  @WebMethod(exclude = true)
+  public String excludedMethod(@WebParam(name = "parameter") String parameter) {
     return parameter;
   }
 
@@ -132,7 +143,10 @@ public class MockedClassForTestingJsonHttp {
    * A method with an incorrectly (non-)annotated header parameter, and a non-header parameter for testing annotations.
    */
   @WebMethod
-  public String methodWithIncorrectlyAnnotatedHeaderParam(@WebParam(name="headerParameter") String headerParameter, @WebParam(name="parameter") String nonHeaderParameter) {
+  public String methodWithIncorrectlyAnnotatedHeaderParam(
+    @WebParam(name = "headerParameter") String headerParameter,
+    @WebParam(name = "parameter") String nonHeaderParameter) {
+
     return headerParameter + nonHeaderParameter;
   }
 
@@ -140,15 +154,17 @@ public class MockedClassForTestingJsonHttp {
   /**
    * A method with a correctly annotated header parameter.
    */
-  @SuppressWarnings("unused")
   @WebMethod
-  public String methodWithCorrectlyAnnotatedHeaderParam(@WebParam(name="headerParameter", header=true) String headerParameter, @WebParam(name="parameter") String nonHeaderParameter) {
+  public String methodWithCorrectlyAnnotatedHeaderParam(
+    @WebParam(name = "headerParameter", header = true) String headerParameter,
+    @WebParam(name = "parameter") String nonHeaderParameter) {
+
     return "The method has been invoked!";
   }
 
 
   public String getParameter() {
-    return parameter;
+    return "";
   }
 
 }

--- a/src/test/java/org/alfasoftware/soapstone/testsupport/PoorVisibility.java
+++ b/src/test/java/org/alfasoftware/soapstone/testsupport/PoorVisibility.java
@@ -20,6 +20,7 @@ package org.alfasoftware.soapstone.testsupport;
  *
  * @author Copyright (c) Alfa Financial Software 2019
  */
+@SuppressWarnings("unused")
 public class PoorVisibility {
 
   /**
@@ -33,8 +34,8 @@ public class PoorVisibility {
     * Private types to cause {@link IllegalAccessException} in type conversion.
     */
   private static class Wrapper {
-    private static enum PrivateEnum {
-      A, B, C;
+    private enum PrivateEnum {
+      A, B, C
     }
   }
  }

--- a/src/test/java/org/alfasoftware/soapstone/testsupport/ProblematicInvocation.java
+++ b/src/test/java/org/alfasoftware/soapstone/testsupport/ProblematicInvocation.java
@@ -22,6 +22,7 @@ import java.nio.charset.UnsupportedCharsetException;
  *
  * @author Copyright (c) Alfa Financial Software 2019
  */
+@SuppressWarnings("unused")
 public class ProblematicInvocation {
 
   /**
@@ -32,7 +33,6 @@ public class ProblematicInvocation {
    * @return converted instance.
    * @throws UnsupportedCharsetException always thrown.
    */
-  @SuppressWarnings("unused")
   public static ProblematicInvocation valueOf(String source) throws UnsupportedCharsetException {
     throw new UnsupportedCharsetException("kdkkdkkdk-199");
   }


### PR DESCRIPTION
Type parameters are lost when unmarshalling e.g. a List<SomeEnum> here:

```
    Object object = typeConverter.convertValue(argumentAsString, type);

    if (object != null) {
      return object;
    }

    try {
      return Mappers.INSTANCE.getObjectMapper().readValue(argumentAsString, operationParameter.getType());
    } catch (IOException e) {
      e.printStackTrace();
      throw new BadRequestException();
    }
```
As a result this unmarshalls to e.g. a List containing strings which then results in a failure inside the invoked method.