### PR TITLE
Simple string parameters in POST body come through doubly quoted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 .idea/
+soapstone.iml
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.alfasoftware</groupId>
   <artifactId>soapstone</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 
   <name>soapstone</name>
   <description>soapstone is a library for exposing API catalogues of JAX-WS SOAP web services as JSON/HTTP.</description>

--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
@@ -171,7 +171,14 @@ public class SoapstoneService {
     }
 
     if (jsonNode != null) {
-      jsonNode.fields().forEachRemaining(entry -> nonHeaderParameters.put(entry.getKey(), entry.getValue().asText()));
+      jsonNode.fields().forEachRemaining(entry -> {
+
+        String parameterName = entry.getKey();
+        JsonNode parameterValue = entry.getValue();
+        String stringValue = parameterValue.isTextual() ? parameterValue.asText() : parameterValue.toString();
+
+        nonHeaderParameters.put(parameterName, stringValue);
+      });
     }
 
     return (String) execute(uriInfo.getPath(), nonHeaderParameters, headerParameter);

--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
@@ -14,8 +14,19 @@
  */
 package org.alfasoftware.soapstone;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
+import static javax.ws.rs.HttpMethod.DELETE;
+import static javax.ws.rs.HttpMethod.GET;
+import static javax.ws.rs.HttpMethod.POST;
+import static javax.ws.rs.HttpMethod.PUT;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.alfasoftware.soapstone.Utils.processHeaders;
+import static org.alfasoftware.soapstone.Utils.simplifyQueryParameters;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
@@ -31,19 +42,9 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
 
-import static javax.ws.rs.HttpMethod.DELETE;
-import static javax.ws.rs.HttpMethod.GET;
-import static javax.ws.rs.HttpMethod.POST;
-import static javax.ws.rs.HttpMethod.PUT;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.alfasoftware.soapstone.Utils.processHeaders;
-import static org.alfasoftware.soapstone.Utils.simplifyQueryParameters;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 
 
 /**
@@ -170,7 +171,7 @@ public class SoapstoneService {
     }
 
     if (jsonNode != null) {
-      jsonNode.fields().forEachRemaining(entry -> nonHeaderParameters.put(entry.getKey(), entry.getValue().toString()));
+      jsonNode.fields().forEachRemaining(entry -> nonHeaderParameters.put(entry.getKey(), entry.getValue().asText()));
     }
 
     return (String) execute(uriInfo.getPath(), nonHeaderParameters, headerParameter);

--- a/src/main/java/org/alfasoftware/soapstone/Utils.java
+++ b/src/main/java/org/alfasoftware/soapstone/Utils.java
@@ -14,14 +14,10 @@
  */
 package org.alfasoftware.soapstone;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.UriInfo;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -32,9 +28,14 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.util.regex.Pattern.CASE_INSENSITIVE;
-import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Utility class containing methods used by the {@link SoapstoneService}.
@@ -78,7 +79,7 @@ class Utils {
     for (String key : queryParameters.keySet()) {
       List<String> values = Optional.ofNullable(queryParameters.get(key)).orElseGet(ArrayList::new);
       if (values.size() == 1) {
-        simplifiedQueryParameters.put(key, queryParameters.getFirst(key));
+        simplifiedQueryParameters.put(key, values.get(0));
       } else {
         try {
           simplifiedQueryParameters.put(key, objectMapper.writeValueAsString(values));

--- a/src/main/java/org/alfasoftware/soapstone/WebServiceClass.java
+++ b/src/main/java/org/alfasoftware/soapstone/WebServiceClass.java
@@ -218,7 +218,7 @@ public class WebServiceClass<T> {
 
     /*
      * The only other option is JSON. Try the mapper. If it doesn't work, then the request is
-     *presumably malformed
+     * presumably malformed
      */
     JavaType type = INSTANCE.getObjectMapper().constructType(operationParameter.getParameterizedType());
 

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
@@ -14,6 +14,23 @@
  */
 package org.alfasoftware.soapstone;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.NotAllowedException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,22 +40,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import javax.ws.rs.NotAllowedException;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.UriInfo;
-import java.util.HashMap;
-import java.util.Map;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 /**
@@ -63,6 +64,7 @@ public class TestSoapstoneService {
   private static final String KEY_2 = "key2";
   private static final String PATH = "/path/path/path";
   private static final String ENTITY = "{ \"entityIdentifier\" : { \"entityDescriptor\":\"descriptor\", \"entityNumber\" : 1 } }";
+  private static final String ENTITY_SIMPLE_PARMS = "{ \"string\" : \"string\", \"boolean\" : true, \"integer\" : 123, \"decimal\" : 33.24 }";
   private static final String ENTITY_IN_JSON = "{\"entityDescriptor\":\"descriptor\",\"entityNumber\":1}";
   private static final String REQUEST_IN_JSON = "{\"realmId\":\"REALM\",\"localeCode\":\"en_gb\",\"userId\":\"USER\"}";
 
@@ -149,6 +151,34 @@ public class TestSoapstoneService {
     assertEquals("The second key and value query combination is incorrect", "[\"value2\",\"value3\"]", capturedNonHeaderValues.get(KEY_2));
     assertEquals("The context is incorrect", REQUEST_IN_JSON, capturedHeaderValues.get("context"));
     assertEquals("The entity is incorrect", ENTITY_IN_JSON, capturedNonHeaderValues.get("entityIdentifier"));
+  }
+
+
+  /**
+   * Tests that we correctly handle simple (e.g., String/primitive) parameters in payloads
+   */
+  @Test
+  public void testProcessingSimpleParameters() {
+
+    // Given
+    String operation = "anyOperation";
+    when(uriInfo.getPath()).thenReturn(PATH + "/" + operation);
+    soapstoneService = createService();
+
+    // When
+    soapstoneService.post(headers, uriInfo, ENTITY_SIMPLE_PARMS);
+
+    // Then
+    // Verify we invoke the operation
+    verify(webServiceClass).invokeOperation(eq(operation), captor.capture(), captor.capture());
+
+    // Verify we populate the parameters with the correct simple parameter strings
+    Map<String, String> capturedNonHeaderValues = captor.getAllValues().get(0);
+    assertEquals("String parameter incorrectly handled", "string", capturedNonHeaderValues.get("string"));
+    assertEquals("Boolean parameter incorrectly handled", "true", capturedNonHeaderValues.get("boolean"));
+    assertEquals("Integer parameter incorrectly handled", "123", capturedNonHeaderValues.get("integer"));
+    assertEquals("Decimal parameter incorrectly handled", "33.24", capturedNonHeaderValues.get("decimal"));
+
   }
 
 

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
@@ -178,7 +178,6 @@ public class TestSoapstoneService {
     assertEquals("Boolean parameter incorrectly handled", "true", capturedNonHeaderValues.get("boolean"));
     assertEquals("Integer parameter incorrectly handled", "123", capturedNonHeaderValues.get("integer"));
     assertEquals("Decimal parameter incorrectly handled", "33.24", capturedNonHeaderValues.get("decimal"));
-
   }
 
 


### PR DESCRIPTION
A payload such as the following:
```json
{ "stringParm" : "str", "intParm" : 123456 }
```
Is parsed into a JsonNode to hold the map of parameters to objects. The objects are then `toString()`'d into the general parameter map. For complex objects and all primitives I've checked so far, this is fine as we know we need to de-string them later. For strings however, we obviously want to just leave them as they are. `toString()` unfortunately requotes, and we get `""str""`.

Using `asText()` will give us the correct representation for strings `toString()` is still ok for everything else, though we shouldn't really be relying on `toString()` as API - this should be considered an interim solution. Possibly a better approach would be to handle all parameters as JsonNodes rather than Strings?