### PR TITLE
Standardise paths used to key web services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 jobs:
   include:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.alfasoftware</groupId>
   <artifactId>soapstone</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.2.1</version>
 
   <name>soapstone</name>
   <description>soapstone is a library for exposing API catalogues of JAX-WS SOAP web services as JSON/HTTP.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.alfasoftware</groupId>
   <artifactId>soapstone</artifactId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
 
   <name>soapstone</name>
   <description>soapstone is a library for exposing API catalogues of JAX-WS SOAP web services as JSON/HTTP.
@@ -23,6 +23,7 @@
     <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
     <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <build>

--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
@@ -44,6 +44,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -160,7 +161,7 @@ public class SoapstoneService {
   public Set<String> getOpenApiTags() {
     LOG.info("Retrieving list of tags for Open API");
     return configuration.getWebServiceClasses().keySet().stream()
-      .map(path -> path.split("/")[1])
+      .map(path -> path.split("/")[0])
       .collect(Collectors.toCollection(TreeSet::new));
   }
 
@@ -237,7 +238,7 @@ public class SoapstoneService {
    */
   private String process(HttpHeaders headers, UriInfo uriInfo, String entity, String method) {
 
-    String fullPath = uriInfo.getPath();
+    String fullPath = StringUtils.strip(uriInfo.getPath(), "/");
     // Check we have a legal path: path/operation
     if (fullPath.indexOf('/') < 0) {
       LOG.error("Path " + fullPath + "should include an operation");

--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneServiceBuilder.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneServiceBuilder.java
@@ -19,8 +19,10 @@ import static com.fasterxml.jackson.databind.MapperFeature.USE_WRAPPER_NAME_AS_P
 import static com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS;
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUMS_USING_TO_STRING;
+import static java.util.stream.Collectors.toMap;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -35,6 +37,7 @@ import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import io.swagger.v3.core.converter.ModelConverters;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Builder for the {@link SoapstoneService}
@@ -63,7 +66,12 @@ public class SoapstoneServiceBuilder {
    * @param pathToWebServiceClassMap map of paths to web service classes
    */
   public SoapstoneServiceBuilder(Map<String, WebServiceClass<?>> pathToWebServiceClassMap) {
-    configuration.setWebServiceClasses(pathToWebServiceClassMap);
+
+    // Standardise the map keys: remove any leading or trailing '/' characters
+    Map<String, WebServiceClass<?>> standardisedMap = pathToWebServiceClassMap.entrySet().stream()
+      .collect(toMap(entry -> StringUtils.strip(entry.getKey(), "/"), Entry::getValue));
+
+    configuration.setWebServiceClasses(standardisedMap);
   }
 
 

--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneServiceBuilder.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneServiceBuilder.java
@@ -14,22 +14,6 @@
  */
 package org.alfasoftware.soapstone;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-import static com.fasterxml.jackson.databind.MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME;
-import static com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS;
-import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
-import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUMS_USING_TO_STRING;
-import static java.util.stream.Collectors.toMap;
-
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.regex.Pattern;
-
-import javax.ws.rs.WebApplicationException;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,6 +22,21 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import io.swagger.v3.core.converter.ModelConverters;
 import org.apache.commons.lang3.StringUtils;
+
+import javax.ws.rs.WebApplicationException;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME;
+import static com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUMS_USING_TO_STRING;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * Builder for the {@link SoapstoneService}


### PR DESCRIPTION
Standardise paths used to key web services by stripping any leading '/' characters. It seems that in different implementations of `javax.ws.rs.*`, `UriInfo#getPath()` will return the path with or without a leading '/'.

I haven't investigated particularly thoroughly, but it is quick and easy to standardise the paths and probably a good idea anyway.