### PR TITLE
Hostname not visible behind reverse proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,9 @@
             </includes>
             <targetPath>META-INF/</targetPath>
           </resource>
+          <resource>
+            <directory>src/main/resources</directory>
+          </resource>
         </resources>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.alfasoftware</groupId>
   <artifactId>soapstone</artifactId>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
 
   <name>soapstone</name>
   <description>soapstone is a library for exposing API catalogues of JAX-WS SOAP web services as JSON/HTTP.

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
       <version>2.0</version>
     </dependency>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
+    </dependency>
+    <dependency>
       <groupId>com.sun.xml.ws</groupId>
       <artifactId>jaxws-ri</artifactId>
       <version>2.3.2</version>
@@ -147,8 +152,13 @@
       <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.28.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-
 
   <profiles>
     <profile>

--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneOpenApiReader.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneOpenApiReader.java
@@ -113,7 +113,7 @@ class SoapstoneOpenApiReader implements OpenApiReader {
 
     Map<String, Class<?>> pathByClass = soapstoneConfiguration.getWebServiceClasses().entrySet().stream()
       .collect(Collectors.toMap(
-        Entry::getKey,
+        entry -> entry.getKey().startsWith("/") ? entry.getKey() : "/" + entry.getKey(),
         entry -> entry.getValue().getUnderlyingClass(),
         (p, q) -> q,
         TreeMap::new));

--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
@@ -20,6 +20,7 @@ import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.HttpMethod.PUT;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -30,6 +31,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -44,14 +46,13 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.integration.SwaggerConfiguration;
 import io.swagger.v3.oas.models.OpenAPI;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -180,9 +181,12 @@ public class SoapstoneService {
   @GET
   @Path("openapi.json")
   @Produces(APPLICATION_JSON)
-  public String getOpenApiJson(@Context UriInfo uriInfo, @QueryParam("tag") Set<String> tags) {
+  public String getOpenApiJson(
+    @Context UriInfo uriInfo, @Context HttpServletRequest request, @QueryParam("tag") Set<String> tags) {
+
     LOG.info("Retrieving Open API JSON");
-    return Json.pretty(getOpenAPI(uriInfo.getBaseUri().toASCIIString(), tags));
+    URI baseUri = uriInfo.getBaseUriBuilder().host(request.getServerName()).build();
+    return Json.pretty(getOpenAPI(baseUri.toASCIIString(), tags));
   }
 
 
@@ -200,9 +204,13 @@ public class SoapstoneService {
   @GET
   @Path("openapi.yaml")
   @Produces("text/vnd.yaml")
-  public String getOpenApiYaml(@Context UriInfo uriInfo, @QueryParam("tag") Set<String> tags) {
+  public String getOpenApiYaml(
+    @Context UriInfo uriInfo, @Context HttpServletRequest request, @QueryParam("tag") Set<String> tags) {
+
     LOG.info("Retrieving Open API YAML");
-    return Yaml.pretty(getOpenAPI(uriInfo.getBaseUri().toASCIIString(), tags));
+
+    URI baseUri = uriInfo.getBaseUriBuilder().host(request.getServerName()).build();
+    return Yaml.pretty(getOpenAPI(baseUri.toASCIIString(), tags));
   }
 
 

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
@@ -24,6 +24,7 @@ import static org.alfasoftware.soapstone.testsupport.WebService.Value.VALUE_2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,26 +36,27 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.jws.WebMethod;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.alfasoftware.soapstone.testsupport.WebService;
 import org.alfasoftware.soapstone.testsupport.WebService.MyException;
 import org.alfasoftware.soapstone.testsupport.WebService.RequestObject;
 import org.alfasoftware.soapstone.testsupport.WebService.ResponseObject;
 import org.glassfish.hk2.api.TypeLiteral;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.filter.LoggingFilter;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.joda.time.LocalDate;
 import org.junit.Test;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 
 /**
@@ -81,9 +83,6 @@ public class TestSoapstoneService extends JerseyTest {
   };
 
 
-//  private SoapstoneConfiguration configuration;
-
-
   @Override
   protected Application configure() {
 
@@ -99,7 +98,13 @@ public class TestSoapstoneService extends JerseyTest {
       .withTagProvider(TAG_PROVIDER)
       .build();
 
-    return new ResourceConfig().registerInstances(service).register(LoggingFilter.class);
+    return new ResourceConfig().registerInstances(service).register(LoggingFilter.class)
+      .register(new AbstractBinder() {
+        @Override
+        protected void configure() {
+          bind(mock(HttpServletRequest.class)).to(HttpServletRequest.class);
+        }
+      });
   }
 
 
@@ -592,7 +597,8 @@ public class TestSoapstoneService extends JerseyTest {
       .path("openapi/tags")
       .request()
       .accept(MediaType.APPLICATION_JSON)
-      .get(new TypeLiteral<List<String>>(){}.getRawType());
+      .get(new TypeLiteral<List<String>>() {
+      }.getRawType());
 
     assertTrue(response.contains("path"));
   }


### PR DESCRIPTION
Paths produced in openAPI documentation are incorrect when accessed via a reverse proxy. This is because `UriInfo` does not expose the correct hostname, whereas `HttpServletRequest` does. 