### PR TITLE
Permit non-word characters in header parameters

### DIFF
--- a/src/main/java/org/alfasoftware/soapstone/WebParameterMapper.java
+++ b/src/main/java/org/alfasoftware/soapstone/WebParameterMapper.java
@@ -54,7 +54,7 @@ class WebParameterMapper {
 
 
   private static final Logger LOG = LoggerFactory.getLogger(WebParameterMapper.class);
-  private static final Pattern VALID_HEADER_FORMAT = Pattern.compile("((:?\\w+)=(\\w+)(;|$))+");
+  private static final Pattern VALID_HEADER_FORMAT = Pattern.compile("((:?\\w+)=([^;]+)(;|$))+");
 
   private final SoapstoneConfiguration configuration;
 

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
@@ -349,7 +349,7 @@ public class TestSoapstoneService extends JerseyTest {
       .queryParam("bool", true)
       .queryParam("date", "2019-03-29")
       .request()
-      .header("X-Vendor-Header", "string=headerStringValue;integer=62")
+      .header("X-Vendor-Header", "string=test@email.com;integer=62")
       .accept(MediaType.APPLICATION_JSON)
       .post(Entity.entity(Collections.singletonMap("request", requestObject), MediaType.APPLICATION_JSON), String.class);
 
@@ -358,7 +358,7 @@ public class TestSoapstoneService extends JerseyTest {
     /*
      * Then
      */
-    assertEquals("headerStringValue", responseObject.getHeaderString());
+    assertEquals("test@email.com", responseObject.getHeaderString());
     assertEquals(62, responseObject.getHeaderInteger());
     assertEquals("value", responseObject.getString());
     assertEquals(65, responseObject.getInteger());


### PR DESCRIPTION
Currently we validate header parameters to ensure they contain no non-word characters other than delimiters. This is overly strict, and given headers should be encoded anyway, we should relax this and just ensure that delimiters only appear where they should.