### PR TITLE
Update snakeyaml version for CVE-2017-18640

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
    <groupId>org.alfasoftware</groupId>
    <artifactId>soapstone</artifactId>
-   <version>2.1.1</version>
+   <version>2.1.2</version>
 
    <name>soapstone</name>
    <description>soapstone is a library for exposing API catalogues of JAX-WS SOAP web services as JSON/HTTP.
@@ -127,6 +127,11 @@
          <groupId>com.google.guava</groupId>
          <artifactId>guava</artifactId>
          <version>27.0.1-jre</version>
+      </dependency>
+      <dependency>
+         <groupId>org.yaml</groupId>
+         <artifactId>snakeyaml</artifactId>
+         <version>1.27</version>
       </dependency>
       <dependency>
          <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
[CVE-2017-18640](https://nvd.nist.gov/vuln/detail/CVE-2017-18640)

> The Alias feature in SnakeYAML 1.18 allows entity expansion during a load operation, a related issue to CVE-2003-1564.

This affects versions of snakeyaml up to (excluding) 1.26. Note that we use this library purely for generation of the openapi yaml files from /openapi.yaml and do not use it for parsing. The update is harmless enough though, so we might as well bump it.
