### PR TITLE
Ensure return types include generic type information

### DIFF
--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneServiceBuilder.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneServiceBuilder.java
@@ -268,7 +268,6 @@ public class SoapstoneServiceBuilder {
     ));
 
     // This is the easiest place to put this to ensure that it is added once and once only
-//    ModelConverters.getInstance().addConverter(new SoapstoneModelResolver(configuration));
     ModelConverters.getInstance().addConverter(new ParentAwareModelResolver(configuration));
 
     return new SoapstoneService(configuration);

--- a/src/main/java/org/alfasoftware/soapstone/WebServiceInvoker.java
+++ b/src/main/java/org/alfasoftware/soapstone/WebServiceInvoker.java
@@ -85,7 +85,8 @@ class WebServiceInvoker {
 
     try {
       Object methodReturn = operation.invoke(webServiceClass.getInstance(), operationArgs);
-      return configuration.getObjectMapper().writeValueAsString(methodReturn);
+      JavaType returnType = configuration.getObjectMapper().constructType(operation.getGenericReturnType());
+      return configuration.getObjectMapper().writerFor(returnType).writeValueAsString(methodReturn);
     } catch (InvocationTargetException e) {
       LOG.error("Error produced within invocation of '" + operationName + "'", e);
       throw configuration.getExceptionMapper()

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReader.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReader.java
@@ -43,7 +43,6 @@ import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import io.swagger.v3.core.converter.ModelConverters;
-import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.integration.SwaggerConfiguration;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -126,15 +125,13 @@ public class TestSoapstoneOpenApiReader {
     SoapstoneOpenApiReader reader = new SoapstoneOpenApiReader(HOST_URL, soapstoneConfiguration);
     reader.setConfiguration(new SwaggerConfiguration());
     openAPI = reader.read(null);
-
-    Yaml.prettyPrint(openAPI);
   }
 
 
   @Test
   public void testAllPathsExist() {
 
-    assertEquals(8, openAPI.getPaths().size());
+    assertEquals(9, openAPI.getPaths().size());
 
     assertTrue(openAPI.getPaths().containsKey("/path/doAThing"));
     assertTrue(openAPI.getPaths().containsKey("/path/doASimpleThing"));
@@ -144,6 +141,7 @@ public class TestSoapstoneOpenApiReader {
     assertTrue(openAPI.getPaths().containsKey("/path/getAThing"));
     assertTrue(openAPI.getPaths().containsKey("/path/putAThing"));
     assertTrue(openAPI.getPaths().containsKey("/path/deleteAThing"));
+    assertTrue(openAPI.getPaths().containsKey("/path/getAListOfThings"));
   }
 
 
@@ -254,7 +252,10 @@ public class TestSoapstoneOpenApiReader {
       "PathDoAListOfThingsRequest",
       "PathDoAThingWithThisNameRequest",
       "PathDoAThingBadlyRequest",
-      "PathPutAThingRequest"
+      "PathPutAThingRequest",
+      "SuperClass",
+      "SubClass1",
+      "SubClass2"
     ));
   }
 

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReader.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReader.java
@@ -68,6 +68,7 @@ import org.junit.Test;
  */
 public class TestSoapstoneOpenApiReader {
 
+
   private static final String HOST_URL = "http://localhost/ctx/";
   private static OpenAPI openAPI;
 
@@ -354,4 +355,5 @@ public class TestSoapstoneOpenApiReader {
 
     return schema;
   }
+
 }

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
@@ -14,6 +14,7 @@
  */
 package org.alfasoftware.soapstone;
 
+import static java.util.Arrays.asList;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
@@ -21,9 +22,12 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.alfasoftware.soapstone.testsupport.WebService.Value.VALUE_1;
 import static org.alfasoftware.soapstone.testsupport.WebService.Value.VALUE_2;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -44,7 +48,9 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.alfasoftware.soapstone.testsupport.WebService;
@@ -632,6 +638,27 @@ public class TestSoapstoneService extends JerseyTest {
 
     assertEquals(METHOD_NOT_ALLOWED.getStatusCode(), response.getStatus());
   }
+
+
+  /**
+   * Test that we get type information when returning a list of some supertype
+   */
+   @Test
+   public void testGetAListOfThings() throws JsonProcessingException {
+
+     String response = target()
+       .path("path/getAListOfThings")
+       .request()
+       .get(String.class);
+
+     JavaType returnType = OBJECT_MAPPER.constructType(new TypeLiteral<List<WebService.SuperClass>>() {}.getType());
+     List<WebService.SuperClass> list = OBJECT_MAPPER.readerFor(returnType).readValue(response);
+
+     assertThat(list, containsInAnyOrder(asList(
+       instanceOf(WebService.SuperClass.SubClass1.class),
+       instanceOf(WebService.SuperClass.SubClass2.class)
+     )));
+   }
 
 
   /**

--- a/src/test/java/org/alfasoftware/soapstone/testsupport/WebService.java
+++ b/src/test/java/org/alfasoftware/soapstone/testsupport/WebService.java
@@ -15,6 +15,7 @@
 package org.alfasoftware.soapstone.testsupport;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -31,6 +32,8 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.joda.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -50,6 +53,7 @@ public class WebService {
   @Retention(RUNTIME)
   public @interface Documentation {
     String value();
+
     String returnValue() default "";
   }
 
@@ -279,6 +283,17 @@ public class WebService {
     VALUE_1, VALUE_2
   }
 
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "className")
+  @JsonSubTypes({
+    @JsonSubTypes.Type(name = "SubClass1", value = SuperClass.SubClass1.class),
+    @JsonSubTypes.Type(name = "SubClass2", value = SuperClass.SubClass2.class)
+  })
+  public static abstract class SuperClass {
+
+    public static class SubClass1 extends SuperClass {}
+    public static class SubClass2 extends SuperClass {}
+  }
+
 
   /**
    * Web service method to take a variety of complex and simple headerString non-headerString
@@ -438,5 +453,14 @@ public class WebService {
    */
   @WebMethod()
   public void deleteAThing() {
+  }
+
+
+  /**
+   * Return a list of things
+   */
+  @WebMethod()
+  public List<SuperClass> getAListOfThings() {
+    return asList(new SuperClass.SubClass1(), new SuperClass.SubClass2());
   }
 }


### PR DESCRIPTION
Currently we fall foul of the issue mention here: https://github.com/FasterXML/jackson-databind/issues/1816.

Where the return type of an operation is generified by some type with subtypes, the subtype information is lost. This occurs because we don't provide the object mapper with any information other than the returned object itself. Providing it with additional type information from the operation `Method`, which we have anyway, allows us to fully serialise.