### PR TITLE
Remove Guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,11 +129,6 @@
          <version>2.1.5</version>
       </dependency>
       <dependency>
-         <groupId>com.google.guava</groupId>
-         <artifactId>guava</artifactId>
-         <version>27.0.1-jre</version>
-      </dependency>
-      <dependency>
          <groupId>org.yaml</groupId>
          <artifactId>snakeyaml</artifactId>
          <version>1.27</version>

--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneOpenApiReader.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneOpenApiReader.java
@@ -14,9 +14,8 @@
  */
 package org.alfasoftware.soapstone;
 
-import static com.google.common.base.CaseFormat.LOWER_CAMEL;
-import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 import java.lang.reflect.Method;
@@ -37,7 +36,6 @@ import javax.jws.WebMethod;
 import javax.jws.WebParam;
 
 import com.fasterxml.jackson.databind.JavaType;
-import com.google.common.base.Strings;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.converter.ResolvedSchema;
@@ -62,6 +60,7 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.servers.Server;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,7 +157,7 @@ class SoapstoneOpenApiReader implements OpenApiReader {
 
         String operationName = ofNullable(method.getAnnotation(WebMethod.class))
           .map(WebMethod::operationName)
-          .map(Strings::emptyToNull)
+          .map(StringUtils::trimToNull)
           .orElse(method.getName());
         LOG.debug("    Operation: " + operationName);
 
@@ -185,8 +184,8 @@ class SoapstoneOpenApiReader implements OpenApiReader {
   private PathItem methodToPathItem(String tag, Method method, String resourcePath, String operationName, Components components) {
 
     String operationId = Arrays.stream(resourcePath.split("\\W"))
-      .map(path -> LOWER_CAMEL.to(UPPER_CAMEL, path))
-      .collect(Collectors.joining()) + LOWER_CAMEL.to(UPPER_CAMEL, operationName);
+      .map(StringUtils::capitalize)
+      .collect(Collectors.joining()) + capitalize(operationName);
 
     List<Parameter> methodParameters = Arrays.stream(method.getParameters())
       .filter(methodParameter -> methodParameter.isAnnotationPresent(WebParam.class))
@@ -313,7 +312,7 @@ class SoapstoneOpenApiReader implements OpenApiReader {
   private HeaderParameter parameterToHeaderParameter(Parameter parameter, Components components) {
 
     String parameterName = ofNullable(trimToNull(parameter.getAnnotation(WebParam.class).name())).orElse(parameter.getName());
-    String headerName = "X-" + soapstoneConfiguration.getVendor() + "-" + LOWER_CAMEL.to(UPPER_CAMEL, parameterName);
+    String headerName = "X-" + soapstoneConfiguration.getVendor() + "-" + capitalize(parameterName);
     String headerId = headerName.replaceAll("\\W", "");
 
     HeaderParameter headerParameter = new HeaderParameter();
@@ -368,7 +367,7 @@ class SoapstoneOpenApiReader implements OpenApiReader {
       return null;
     }
 
-    String requestBodyName = LOWER_CAMEL.to(UPPER_CAMEL, operationId) + "Request";
+    String requestBodyName = capitalize(operationId) + "Request";
 
     Schema<?> schema = new ObjectSchema();
     schema.setName(requestBodyName);

--- a/src/main/java/org/alfasoftware/soapstone/WebParameterMapper.java
+++ b/src/main/java/org/alfasoftware/soapstone/WebParameterMapper.java
@@ -14,13 +14,12 @@
  */
 package org.alfasoftware.soapstone;
 
-import static com.google.common.base.CaseFormat.LOWER_CAMEL;
-import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.alfasoftware.soapstone.WebParameter.headerParameter;
 import static org.alfasoftware.soapstone.WebParameter.parameter;
+import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -142,7 +141,7 @@ class WebParameterMapper {
     // ... create the object...
     Map<String, String> object = createObject(headers, objectHeaderName);
     // ... and add it to the map
-    String key = UPPER_CAMEL.to(LOWER_CAMEL, objectHeaderName.substring(objectHeaderName.lastIndexOf("-") + 1));
+    String key = uncapitalize(objectHeaderName.substring(objectHeaderName.lastIndexOf("-") + 1));
     JsonNode value = configuration.getObjectMapper().valueToTree(object);
     headerObjects.add(headerParameter(key, value));
   }
@@ -217,8 +216,7 @@ class WebParameterMapper {
 
     String value = headers.getHeaderString(objectPropertyHeaderName);
 
-    String propertyName = objectPropertyHeaderName.substring(objectPropertyHeaderName.lastIndexOf("-") + 1);
-    String key = UPPER_CAMEL.to(LOWER_CAMEL, propertyName);
+    String key = uncapitalize(objectPropertyHeaderName.substring(objectPropertyHeaderName.lastIndexOf("-") + 1));
 
     object.put(key, value);
   }

--- a/src/main/java/org/alfasoftware/soapstone/WebServiceInvoker.java
+++ b/src/main/java/org/alfasoftware/soapstone/WebServiceInvoker.java
@@ -35,7 +35,7 @@ import javax.xml.bind.annotation.XmlElement;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
-import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -162,7 +162,7 @@ class WebServiceInvoker {
 
     String methodOperationName = Optional.ofNullable(method.getAnnotation(WebMethod.class))
       .map(WebMethod::operationName)
-      .map(Strings::emptyToNull)
+      .map(StringUtils::trimToNull)
       .orElse(method.getName());
 
     return methodOperationName.equals(operationName);

--- a/src/test/java/org/alfasoftware/soapstone/external/TestExternalCreation.java
+++ b/src/test/java/org/alfasoftware/soapstone/external/TestExternalCreation.java
@@ -16,14 +16,13 @@ package org.alfasoftware.soapstone.external;
 
 import java.util.HashMap;
 import java.util.Optional;
+import java.util.function.Function;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.alfasoftware.soapstone.DocumentationProviderBuilder;
 import org.alfasoftware.soapstone.SoapstoneServiceBuilder;
 import org.alfasoftware.soapstone.WebServiceClass;
 import org.junit.Test;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Functions;
 
 /**
  * Trivial test to ensure everything is publicly visible that needs to be
@@ -47,7 +46,7 @@ public class TestExternalCreation {
       .withSupportedPutOperations("put.*")
       .withSupportedDeleteOperations("delete.*")
       .withDocumentationProvider(new DocumentationProviderBuilder().build())
-      .withTagProvider(Functions.identity())
+      .withTagProvider(Function.identity())
       .build();
   }
 }


### PR DESCRIPTION
As per #34 there is a security vulnerability in the version of Guava we are using. On inspection we can actually fairly trivially remove this dependency altogether, so we will go with that rather than upgrade.

We currently use Guava's `CaseFormat` for mapping between camel and pascal case for which we can just use Apache's `StringUtils#capitalize` and `StringUtils#uncapoitalize` (StringUtils is already a dependency). We also have a single use of `Functions.identity()` in a test which can be replaced with Java's `Function.identity()` (or just `a -> a` if we wanted).