### PR TITLE
DataHandler should be documented as a simple string type

### DIFF
--- a/src/main/java/org/alfasoftware/soapstone/ParentAwareModelResolver.java
+++ b/src/main/java/org/alfasoftware/soapstone/ParentAwareModelResolver.java
@@ -14,19 +14,6 @@
  */
 package org.alfasoftware.soapstone;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-
-import java.lang.annotation.Annotation;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Function;
-
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.BeanDescription;
@@ -43,6 +30,19 @@ import io.swagger.v3.core.jackson.TypeNameResolver;
 import io.swagger.v3.oas.models.media.Discriminator;
 import io.swagger.v3.oas.models.media.Schema;
 import org.apache.commons.lang3.StringUtils;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 
 
 /**
@@ -70,6 +70,13 @@ class ParentAwareModelResolver extends ModelResolver {
 
     if (annotatedType == null) {
       return null;
+    }
+
+    if (annotatedType.getType().getTypeName().contains("javax.activation.DataHandler")) {
+      annotatedType.setType(_mapper.constructType(String.class));
+      Schema<?> dataHandlerSchema = super.resolve(annotatedType, context, chain);
+      dataHandlerSchema.setFormat("byte");
+      return dataHandlerSchema;
     }
 
     JavaType type;

--- a/src/main/java/org/alfasoftware/soapstone/ParentAwareModelResolver.java
+++ b/src/main/java/org/alfasoftware/soapstone/ParentAwareModelResolver.java
@@ -14,6 +14,19 @@
  */
 package org.alfasoftware.soapstone;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.BeanDescription;
@@ -30,19 +43,6 @@ import io.swagger.v3.core.jackson.TypeNameResolver;
 import io.swagger.v3.oas.models.media.Discriminator;
 import io.swagger.v3.oas.models.media.Schema;
 import org.apache.commons.lang3.StringUtils;
-
-import java.lang.annotation.Annotation;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Function;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 
 
 /**

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReader.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReader.java
@@ -345,6 +345,11 @@ public class TestSoapstoneOpenApiReader {
       hasProperty("type", is("string")),
       hasProperty("description", is("Method: ResponseObject#getAdaptable()"))
     ));
+
+    assertThat(schema.getProperties().get("dataHandler"), allOf(
+      hasProperty("type", is("string")),
+      hasProperty("format", is("byte"))
+    ));
   }
 
 

--- a/src/test/java/org/alfasoftware/soapstone/testsupport/WebService.java
+++ b/src/test/java/org/alfasoftware/soapstone/testsupport/WebService.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.activation.DataHandler;
 import javax.jws.WebMethod;
 import javax.jws.WebParam;
 import javax.xml.bind.annotation.XmlElement;
@@ -139,6 +140,7 @@ public class WebService {
     private boolean bool;
     private LocalDate date;
     private Adaptable adaptable;
+    private DataHandler dataHandler;
 
     public RequestObject getNestedObject() {
       return nestedObject;
@@ -177,6 +179,10 @@ public class WebService {
     @Documentation("Method: ResponseObject#getAdaptable()")
     public Adaptable getAdaptable() {
       return adaptable;
+    }
+
+    public DataHandler getDataHandler() {
+      return dataHandler;
     }
   }
 


### PR DESCRIPTION
DataHandler should be documented as a simple string type with base64 encoding (format=byte) rather than a complex object type