### PR TITLE
Process supertypes eagerly and prior to processing subtypes

### DIFF
--- a/src/main/java/org/alfasoftware/soapstone/ParentAwareModelResolver.java
+++ b/src/main/java/org/alfasoftware/soapstone/ParentAwareModelResolver.java
@@ -109,8 +109,8 @@ class ParentAwareModelResolver extends ModelResolver {
     if (convertedType != null) {
 
       return resolve(new AnnotatedType()
-        .type(convertedType)
-        .ctxAnnotations(annotatedType.getCtxAnnotations()), context, chain);
+          .type(convertedType)
+          .ctxAnnotations(annotatedType.getCtxAnnotations()), context, chain);
     }
 
     definedTypes.putIfAbsent(_typeName(type), type);
@@ -127,21 +127,27 @@ class ParentAwareModelResolver extends ModelResolver {
       return defaultDescription;
     }
 
-    Collection<Annotation> contextAnnotations = annotations != null ? asList(annotations) : emptyList();
-
-    Optional<String> descriptionFromContext = configuration.getDocumentationProvider()
-      .flatMap(provider -> provider.forModelProperty(contextAnnotations));
-
-    if (!descriptionFromContext.isPresent() && a != null) {
-
-      Collection<Annotation> entityAnnotations = asList(a.getAnnotated().getAnnotations());
-
-      return configuration.getDocumentationProvider()
-        .flatMap(provider -> provider.forModelProperty(entityAnnotations))
-        .orElse(null);
+    if (a == null) {
+      return null;
     }
 
-    return descriptionFromContext.orElse(null);
+    if (a.getType() == null || a.getType().isPrimitive()) {
+      Collection<Annotation> contextAnnotations = annotations != null ? asList(annotations) : emptyList();
+
+      Optional<String> descriptionFromContext = configuration.getDocumentationProvider()
+          .flatMap(provider -> provider.forModelProperty(contextAnnotations));
+
+      if (descriptionFromContext.isPresent()) {
+        return descriptionFromContext.get();
+      }
+    }
+
+    Collection<Annotation> entityAnnotations = asList(a.getAnnotated().getAnnotations());
+
+    return configuration.getDocumentationProvider()
+        .flatMap(provider -> provider.forModelProperty(entityAnnotations))
+        .orElse(null);
+
   }
 
 
@@ -161,9 +167,9 @@ class ParentAwareModelResolver extends ModelResolver {
         BeanDescription parentBeanDescription = _mapper.getSerializationConfig().introspect(parentType);
 
         return parentBeanDescription.findProperties().stream()
-          .filter(property -> property.getName().equals(currentPropertyName))
-          .findFirst()
-          .map(BeanPropertyDefinition::getPrimaryMember);
+            .filter(property -> property.getName().equals(currentPropertyName))
+            .findFirst()
+            .map(BeanPropertyDefinition::getPrimaryMember);
       }
     }
 

--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneConfiguration.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneConfiguration.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 class SoapstoneConfiguration {
 
+
   private ObjectMapper objectMapper;
   private ExceptionMapper exceptionMapper;
   private Map<String, WebServiceClass<?>> webServiceClasses;
@@ -72,24 +73,24 @@ class SoapstoneConfiguration {
     this.vendor = vendor;
   }
 
-  Pattern getSupportedGetOperations() {
-    return supportedGetOperations;
+  Optional<Pattern> getSupportedGetOperations() {
+    return Optional.ofNullable(supportedGetOperations);
   }
 
   void setSupportedGetOperations(Pattern supportedGetOperations) {
     this.supportedGetOperations = supportedGetOperations;
   }
 
-  Pattern getSupportedPutOperations() {
-    return supportedPutOperations;
+  Optional<Pattern> getSupportedPutOperations() {
+    return Optional.ofNullable(supportedPutOperations);
   }
 
   void setSupportedPutOperations(Pattern supportedPutOperations) {
     this.supportedPutOperations = supportedPutOperations;
   }
 
-  Pattern getSupportedDeleteOperations() {
-    return supportedDeleteOperations;
+  Optional<Pattern> getSupportedDeleteOperations() {
+    return Optional.ofNullable(supportedDeleteOperations);
   }
 
   void setSupportedDeleteOperations(Pattern supportedDeleteOperations) {

--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneOpenApiReader.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneOpenApiReader.java
@@ -429,7 +429,7 @@ class SoapstoneOpenApiReader implements OpenApiReader {
     Optional<Converter<?, ?>> parameterConvertor = getParameterConverterForPackage(type, currentResourceClass);
 
     if (parameterConvertor.isPresent()) {
-      javaType = ((Converter<?, ?>) parameterConvertor.get()).getOutputType(soapstoneConfiguration.getObjectMapper().getTypeFactory());
+      javaType = parameterConvertor.get().getOutputType(soapstoneConfiguration.getObjectMapper().getTypeFactory());
       type = javaType.getRawClass();
     }
 

--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -310,18 +309,15 @@ public class SoapstoneService {
     // Find supported operations
     Set<String> supportedMethods = new HashSet<>();
 
-    Pattern supportedGetOperations = configuration.getSupportedGetOperations();
-    if (supportedGetOperations != null && supportedGetOperations.matcher(operationName).matches()) {
+    if (configuration.getSupportedGetOperations().map(p -> p.matcher(operationName).matches()).orElse(false)) {
       supportedMethods.add(GET);
     }
 
-    Pattern supportedDeleteOperations = configuration.getSupportedDeleteOperations();
-    if (supportedDeleteOperations != null && supportedDeleteOperations.matcher(operationName).matches()) {
+    if (configuration.getSupportedDeleteOperations().map(p -> p.matcher(operationName).matches()).orElse(false)) {
       supportedMethods.add(DELETE);
     }
 
-    Pattern supportedPutOperations = configuration.getSupportedPutOperations();
-    if (supportedPutOperations != null && supportedPutOperations.matcher(operationName).matches()) {
+    if (configuration.getSupportedPutOperations().map(p -> p.matcher(operationName).matches()).orElse(false)) {
       supportedMethods.add(PUT);
     }
 

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReaderWithInheritance.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReaderWithInheritance.java
@@ -91,9 +91,6 @@ public class TestSoapstoneOpenApiReaderWithInheritance {
     SoapstoneConfiguration soapstoneConfiguration = new SoapstoneConfiguration();
     soapstoneConfiguration.setWebServiceClasses(webServices);
     soapstoneConfiguration.setObjectMapper(objectMapper);
-    soapstoneConfiguration.setSupportedGetOperations(Pattern.compile("get.*"));
-    soapstoneConfiguration.setSupportedDeleteOperations(Pattern.compile("delete.*"));
-    soapstoneConfiguration.setSupportedPutOperations(Pattern.compile("put.*"));
 
     ModelConverters.getInstance().addConverter(new ParentAwareModelResolver(soapstoneConfiguration));
 

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReaderWithInheritance.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReaderWithInheritance.java
@@ -1,0 +1,176 @@
+/* Copyright 2019 Alfa Financial Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfasoftware.soapstone;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME;
+import static com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUMS_USING_TO_STRING;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.alfasoftware.soapstone.testsupport.InheritanceTestService;
+import org.hamcrest.Matchers;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.oas.integration.SwaggerConfiguration;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+
+/**
+ * Test the {@link SoapstoneOpenApiReader} correctly documents supertypes
+ *
+ * @author Copyright (c) Alfa Financial Software 2021
+ */
+public class TestSoapstoneOpenApiReaderWithInheritance {
+
+
+  private static final String HOST_URL = "http://localhost/ctx/";
+  private static OpenAPI openAPI;
+
+
+  /**
+   * Build the {@link SoapstoneConfiguration} for the service the reader should run over
+   */
+  @BeforeClass
+  public static void setup() {
+
+    AnnotationIntrospector jaxbIntrospector = new JaxbAnnotationIntrospector(TypeFactory.defaultInstance());
+    AnnotationIntrospector jacksonIntrospector = new JacksonAnnotationIntrospector();
+
+    ObjectMapper objectMapper = new ObjectMapper()
+        .setAnnotationIntrospector(AnnotationIntrospector.pair(jacksonIntrospector, jaxbIntrospector))
+        .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(USE_WRAPPER_NAME_AS_PROPERTY_NAME, true)
+        .configure(FAIL_ON_EMPTY_BEANS, false)
+        .configure(WRITE_DATES_AS_TIMESTAMPS, false)
+        .configure(WRITE_ENUMS_USING_TO_STRING, true)
+        .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    Map<String, WebServiceClass<?>> webServices = new HashMap<>();
+    webServices.put("/path", WebServiceClass.forClass(InheritanceTestService.class, InheritanceTestService::new));
+
+    SoapstoneConfiguration soapstoneConfiguration = new SoapstoneConfiguration();
+    soapstoneConfiguration.setWebServiceClasses(webServices);
+    soapstoneConfiguration.setObjectMapper(objectMapper);
+    soapstoneConfiguration.setSupportedGetOperations(Pattern.compile("get.*"));
+    soapstoneConfiguration.setSupportedDeleteOperations(Pattern.compile("delete.*"));
+    soapstoneConfiguration.setSupportedPutOperations(Pattern.compile("put.*"));
+
+    ModelConverters.getInstance().addConverter(new ParentAwareModelResolver(soapstoneConfiguration));
+
+    SoapstoneOpenApiReader reader = new SoapstoneOpenApiReader(HOST_URL, soapstoneConfiguration);
+    reader.setConfiguration(new SwaggerConfiguration());
+    openAPI = reader.read(null);
+  }
+
+
+  @Test
+  public void testAllPathsExist() {
+
+    assertEquals(1, openAPI.getPaths().size());
+
+    assertTrue(openAPI.getPaths().containsKey("/path/doAThingWithInheritance"));
+  }
+
+
+  @Test
+  public void testSuperTypesInSchema() {
+
+    Operation post = openAPI.getPaths().get("/path/doAThingWithInheritance").getPost();
+    assertNotNull(post);
+
+    MediaType jsonMedia = post.getRequestBody().getContent().get("application/json");
+    Schema<?> requestBodySchema = schemaForRefSchema(jsonMedia.getSchema());
+
+    assertThat(requestBodySchema.getProperties().get("type"),
+        hasProperty("$ref", is("#/components/schemas/SubTypeOfSubType"))
+    );
+
+    ComposedSchema type = (ComposedSchema) schemaForRefSchema(requestBodySchema.getProperties().get("type"));
+    assertThat(type,
+        allOf(
+            hasProperty("name", is("SubTypeOfSubType")),
+            hasProperty("discriminator", isEmptyOrNullString()),
+            hasProperty("allOf", contains(hasProperty("$ref", is("#/components/schemas/SubTypeOfModel"))))
+        )
+    );
+
+    ComposedSchema parentType = (ComposedSchema) schemaForRefSchema(type.getAllOf().get(0));
+    assertThat(parentType,
+        allOf(
+            hasProperty("name", is("SubTypeOfModel")),
+            hasProperty("discriminator",
+                allOf(
+                    hasProperty("mapping", hasEntry("SubTypeOfSubType", "#/components/schemas/SubTypeOfSubType")),
+                    hasProperty("propertyName", is("modelClass"))
+                )),
+            hasProperty("allOf", hasItem(hasProperty("$ref", is("#/components/schemas/Model"))))
+        )
+    );
+
+    Schema<?> parentOfParentType = schemaForRefSchema(parentType.getAllOf().get(0));
+    assertThat(parentOfParentType,
+        allOf(
+            hasProperty("name", is("Model")),
+            hasProperty("discriminator",
+                allOf(
+                    hasProperty("mapping", hasEntry("SubTypeOfModel", "#/components/schemas/SubTypeOfModel")),
+                    hasProperty("propertyName", is("modelClass"))
+                )),
+            Matchers.not(hasProperty("allOf"))
+        )
+    );
+  }
+
+
+  private static Schema<?> schemaForRefSchema(Schema<?> refSchema) {
+
+    String ref = refSchema.get$ref();
+    assertNotNull("The passed schema has no $ref: [" + refSchema + "]", ref);
+
+    Schema<?> schema = openAPI.getComponents().getSchemas().get(ref.replaceAll(".*/", ""));
+    assertNotNull("No schema exists for the given ref [" + ref + "]", schema);
+
+    return schema;
+  }
+
+}

--- a/src/test/java/org/alfasoftware/soapstone/testsupport/InheritanceTestService.java
+++ b/src/test/java/org/alfasoftware/soapstone/testsupport/InheritanceTestService.java
@@ -16,7 +16,9 @@ package org.alfasoftware.soapstone.testsupport;
 
 import javax.jws.WebMethod;
 import javax.jws.WebParam;
+import javax.xml.bind.annotation.XmlTransient;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -30,6 +32,7 @@ public class InheritanceTestService {
   /**
    * Type hidden from the API - should not be documented
    */
+  @XmlTransient
   public static class HiddenSuperType {}
 
 

--- a/src/test/java/org/alfasoftware/soapstone/testsupport/InheritanceTestService.java
+++ b/src/test/java/org/alfasoftware/soapstone/testsupport/InheritanceTestService.java
@@ -1,0 +1,75 @@
+/* Copyright 2021 Alfa Financial Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfasoftware.soapstone.testsupport;
+
+import javax.jws.WebMethod;
+import javax.jws.WebParam;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Web service test for testing that inherited API models are documented
+ */
+@SuppressWarnings("unused")
+public class InheritanceTestService {
+
+
+  /**
+   * Type hidden from the API - should not be documented
+   */
+  public static class HiddenSuperType {}
+
+
+  /**
+   * First supertype that should be exposed to the API
+   */
+  @JsonTypeInfo(
+      use = JsonTypeInfo.Id.NAME,
+      property = "modelClass")
+  @JsonSubTypes({
+      @JsonSubTypes.Type(value = SubTypeOfModel.class, name = "SubTypeOfModel")
+  })
+  public static class Model extends HiddenSuperType {
+  }
+
+
+  /**
+   * Second supertype that should be exposed to the API
+   */
+  @JsonTypeInfo(
+      use = JsonTypeInfo.Id.NAME,
+      property = "modelClass")
+  @JsonSubTypes({
+      @JsonSubTypes.Type(value = SubTypeOfSubType.class, name = "SubTypeOfSubType")
+  })
+  public static class SubTypeOfModel extends Model {
+  }
+
+
+  /**
+   * Subtype that should be exposed to the API
+   */
+  public static class SubTypeOfSubType extends SubTypeOfModel {
+  }
+
+
+  /**
+   * Simple operation which will take a type with two levels of super types
+   */
+  @WebMethod()
+  public void doAThingWithInheritance(@WebParam(name = "type") SubTypeOfSubType type) {
+  }
+}


### PR DESCRIPTION
Supertypes are currently inconsistently documented in the OpenAPI spec. Depending on the order in which they are encountered, and whether the supertypes are directly referenced in the tagged operations, polymorphism may not be properly documented resulting in missing discriminators which are likely required.