### PR TITLE
Fix/openapi supertypes not properly generated if not using jackson annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,12 +121,12 @@
       <dependency>
          <groupId>io.swagger.core.v3</groupId>
          <artifactId>swagger-models</artifactId>
-         <version>2.1.12</version>
+         <version>2.1.5</version>
       </dependency>
       <dependency>
          <groupId>io.swagger.core.v3</groupId>
          <artifactId>swagger-integration</artifactId>
-         <version>2.1.12</version>
+         <version>2.1.5</version>
       </dependency>
       <dependency>
          <groupId>org.yaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -121,12 +121,12 @@
       <dependency>
          <groupId>io.swagger.core.v3</groupId>
          <artifactId>swagger-models</artifactId>
-         <version>2.1.5</version>
+         <version>2.1.12</version>
       </dependency>
       <dependency>
          <groupId>io.swagger.core.v3</groupId>
          <artifactId>swagger-integration</artifactId>
-         <version>2.1.5</version>
+         <version>2.1.12</version>
       </dependency>
       <dependency>
          <groupId>org.yaml</groupId>

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReaderWithInheritance.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneOpenApiReaderWithInheritance.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import org.alfasoftware.soapstone.testsupport.InheritanceTestService;
 import org.hamcrest.Matchers;


### PR DESCRIPTION
Inheritance information is missed for subtypes if the subtype is processed before its supertype. This was previously fixed for 'top-level' models, but is still an issue for models first encountered as children of others.