### PR TITLE
Fix/risk of logging sensitive information at info or above

### DIFF
--- a/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
+++ b/src/main/java/org/alfasoftware/soapstone/SoapstoneService.java
@@ -95,7 +95,7 @@ public class SoapstoneService {
   @Produces(APPLICATION_JSON)
   @Consumes(APPLICATION_JSON)
   public String post(@Context HttpHeaders headers, @Context UriInfo uriInfo, String entity) {
-    LOG.info("POST " + uriInfo.getRequestUri());
+    LOG.info("POST " + uriInfo.getAbsolutePath());
     return process(headers, uriInfo, entity, POST);
   }
 
@@ -111,7 +111,7 @@ public class SoapstoneService {
   @Path("/{s:.*}")
   @Produces(APPLICATION_JSON)
   public String get(@Context HttpHeaders headers, @Context UriInfo uriInfo) {
-    LOG.info("GET " + uriInfo.getRequestUri());
+    LOG.info("GET " + uriInfo.getAbsolutePath());
     return process(headers, uriInfo, null, GET);
   }
 
@@ -129,7 +129,7 @@ public class SoapstoneService {
   @Produces(APPLICATION_JSON)
   @Consumes(APPLICATION_JSON)
   public String put(@Context HttpHeaders headers, @Context UriInfo uriInfo, String entity) {
-    LOG.info("PUT " + uriInfo.getRequestUri());
+    LOG.info("PUT " + uriInfo.getAbsolutePath());
     return process(headers, uriInfo, entity, PUT);
   }
 
@@ -147,7 +147,7 @@ public class SoapstoneService {
   @Produces(APPLICATION_JSON)
   @Consumes(APPLICATION_JSON)
   public String delete(@Context HttpHeaders headers, @Context UriInfo uriInfo, String entity) {
-    LOG.info("DELETE " + uriInfo.getRequestUri());
+    LOG.info("DELETE " + uriInfo.getAbsolutePath());
     return process(headers, uriInfo, entity, DELETE);
   }
 

--- a/src/main/java/org/alfasoftware/soapstone/WebParameterMapper.java
+++ b/src/main/java/org/alfasoftware/soapstone/WebParameterMapper.java
@@ -39,10 +39,11 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Utility class containing methods used for extracting {@link WebParameter}s from requests.
@@ -105,9 +106,10 @@ class WebParameterMapper {
       );
     } catch (IOException e) {
 
-      String message = "Unable to parse entity:\n" + entity;
+      String message = "Unable to parse entity";
 
       LOG.warn(message, e);
+      LOG.debug(entity);
       throw new BadRequestException(message);
     }
     return webParameters;

--- a/src/main/java/org/alfasoftware/soapstone/WebServiceInvoker.java
+++ b/src/main/java/org/alfasoftware/soapstone/WebServiceInvoker.java
@@ -33,11 +33,12 @@ import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.xml.bind.annotation.XmlElement;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JavaType;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
 
 /**
  * Locates and invokes web service operations in accordance with JAX-WS annotations and conventions.
@@ -88,20 +89,23 @@ class WebServiceInvoker {
       JavaType returnType = configuration.getObjectMapper().constructType(operation.getGenericReturnType());
       return configuration.getObjectMapper().writerFor(returnType).writeValueAsString(methodReturn);
     } catch (InvocationTargetException e) {
-      LOG.error("Error produced within invocation of '" + operationName + "'", e);
+      LOG.error("Error produced within invocation of '" + operationName + "'");
+      LOG.debug("Original error", e);
       throw configuration.getExceptionMapper()
         .flatMap(mapper -> mapper.mapThrowable(e.getTargetException(), configuration.getObjectMapper()))
         .orElse(new InternalServerErrorException());
 
     } catch (IllegalAccessException e) {
-      LOG.error("Error attempting to access '" + operationName + "'", e);
+      LOG.error("Error attempting to access '" + operationName + "'");
+      LOG.debug("Original error", e);
       /*
        * We've already thoroughly checked that the method was valid and accessible, so this shouldn't happen.
        * If it does, it's something more nefarious than a 404
        */
       throw new InternalServerErrorException();
     } catch (JsonProcessingException e) {
-      LOG.error("Error marshalling response from '" + operationName + "'", e);
+      LOG.error("Error marshalling response from '" + operationName + "'");
+      LOG.debug("Original error", e);
       throw new InternalServerErrorException();
     }
   }
@@ -282,7 +286,8 @@ class WebServiceInvoker {
       }
       return configuration.getObjectMapper().convertValue(parameter.get().getNode(), type);
     } catch (Exception e) {
-      LOG.warn("Error unmarshalling " + parameter.get().getName(), e);
+      LOG.warn("Error unmarshalling " + parameter.get().getName());
+      LOG.debug("Original error", e);
       throw new BadRequestException(parameter.get().getNode() + " could not be unmarshalled to '" + parameterName + "'");
     }
   }

--- a/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
+++ b/src/test/java/org/alfasoftware/soapstone/TestSoapstoneService.java
@@ -22,12 +22,12 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.alfasoftware.soapstone.testsupport.WebService.Value.VALUE_1;
 import static org.alfasoftware.soapstone.testsupport.WebService.Value.VALUE_2;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -48,11 +48,6 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.alfasoftware.soapstone.testsupport.WebService;
 import org.alfasoftware.soapstone.testsupport.WebService.MyException;
 import org.alfasoftware.soapstone.testsupport.WebService.RequestObject;
@@ -66,6 +61,12 @@ import org.joda.time.LocalDate;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 
 /**


### PR DESCRIPTION
There are a number of places where information is included in >=info logs that might result in the exposure of sensitive information. These include: 
 - Logging the passed entity JSON when failing to  unmarshal it
 - Logging the full incoming request URI including query parameters
 - Logging exceptions thrown from the embedding application

In the case of entities or exceptions, the potentially sensitive logs have been reduced to debug level, with a summary message remaining at the current appropriate log level. In the case of request URIs, the query parameters are no longer included in the logged message.