### PR TITLE
Ignore naming collisions on enums

### DIFF
--- a/src/main/java/org/alfasoftware/soapstone/ParentAwareModelResolver.java
+++ b/src/main/java/org/alfasoftware/soapstone/ParentAwareModelResolver.java
@@ -150,6 +150,9 @@ class ParentAwareModelResolver extends ModelResolver {
     // Ignore if either type is primitive, since the collision is probably with the boxed type
     if (type.isPrimitive() || knownType.isPrimitive()) return;
 
+    // Ignore if either type is an enum, since it doesn't need to be represented as a model
+    if (type.isEnumType() || knownType.isEnumType()) return;
+
     // Ignore if the types are both containers, since they will map to the same thing
     if (type.isContainerType() && knownType.isContainerType()) return;
 


### PR DESCRIPTION
Exceptions are currently thrown for type name collisions on enums when generating OpenAPI docs. However, enums are not exposed in those docs as components and so naming collisions do not matter.