### PR TITLE
Move to support servlet 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
    <groupId>org.alfasoftware</groupId>
    <artifactId>soapstone</artifactId>
-   <version>3.3.3-SNAPSHOT</version>
+   <version>4.0.0</version>
 
    <name>soapstone</name>
    <description>soapstone is a library for exposing API catalogues of JAX-WS SOAP web services as JSON/HTTP.

--- a/pom.xml
+++ b/pom.xml
@@ -72,66 +72,66 @@
 
    <dependencies>
       <dependency>
-         <groupId>javax.ws.rs</groupId>
-         <artifactId>javax.ws.rs-api</artifactId>
-         <version>2.0</version>
+         <groupId>jakarta.ws.rs</groupId>
+         <artifactId>jakarta.ws.rs-api</artifactId>
+         <version>2.1.6</version>
       </dependency>
       <dependency>
-         <groupId>javax.servlet</groupId>
-         <artifactId>servlet-api</artifactId>
-         <version>2.5</version>
+         <groupId>jakarta.servlet</groupId>
+         <artifactId>jakarta.servlet-api</artifactId>
+         <version>4.0.4</version>
       </dependency>
       <dependency>
          <groupId>com.sun.xml.ws</groupId>
          <artifactId>jaxws-ri</artifactId>
-         <version>2.3.2</version>
+         <version>2.3.7</version>
          <type>pom</type>
          <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>joda-time</groupId>
          <artifactId>joda-time</artifactId>
-         <version>2.1</version>
+         <version>2.14.0</version>
       </dependency>
       <dependency>
          <groupId>com.fasterxml.jackson.jaxrs</groupId>
          <artifactId>jackson-jaxrs-json-provider</artifactId>
-         <version>2.13.1</version>
+         <version>2.18.3</version>
       </dependency>
       <dependency>
          <groupId>com.fasterxml.jackson.dataformat</groupId>
          <artifactId>jackson-dataformat-xml</artifactId>
-         <version>2.13.1</version>
+         <version>2.18.3</version>
       </dependency>
       <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-lang3</artifactId>
-         <version>3.8</version>
+         <version>3.17.0</version>
       </dependency>
       <dependency>
          <groupId>ognl</groupId>
          <artifactId>ognl</artifactId>
-         <version>3.0.12</version>
+         <version>3.4.7</version>
       </dependency>
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
-         <version>1.7.25</version>
+         <version>1.7.36</version>
       </dependency>
       <dependency>
          <groupId>io.swagger.core.v3</groupId>
          <artifactId>swagger-models</artifactId>
-         <version>2.1.6</version>
+         <version>2.1.13</version>
       </dependency>
       <dependency>
          <groupId>io.swagger.core.v3</groupId>
          <artifactId>swagger-integration</artifactId>
-         <version>2.1.6</version>
+         <version>2.1.13</version>
       </dependency>
       <dependency>
          <groupId>org.yaml</groupId>
          <artifactId>snakeyaml</artifactId>
-         <version>2.0</version>
+         <version>2.4</version>
       </dependency>
       <dependency>
          <groupId>junit</groupId>
@@ -160,19 +160,13 @@
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>jul-to-slf4j</artifactId>
-         <version>1.7.25</version>
+         <version>1.7.36</version>
          <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-simple</artifactId>
-         <version>1.7.25</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.glassfish.hk2</groupId>
-         <artifactId>hk2-api</artifactId>
-         <version>2.2.0</version>
+         <version>1.7.36</version>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/src/main/java/org/alfasoftware/soapstone/DocumentationProviderBuilder.java
+++ b/src/main/java/org/alfasoftware/soapstone/DocumentationProviderBuilder.java
@@ -21,9 +21,10 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
 
-import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 
 /**
  * Builder for {@link DocumentationProvider}
@@ -117,6 +118,8 @@ public class DocumentationProviderBuilder {
 
 
   /**
+   * @param forMember ignored - this method does nothing
+   * @return this
    * @deprecated Use {@link #withModelDocumentationProvider(Function)} to provide documentation for models and members
    */
   @Deprecated
@@ -129,6 +132,8 @@ public class DocumentationProviderBuilder {
 
 
   /**
+   * @param forClass ignored - this method does nothing
+   * @return this
    * @deprecated Use {@link #withModelDocumentationProvider(Function)} to provide documentation for models and members
    */
   @Deprecated


### PR DESCRIPTION
Change dependencies on javax:servlet-api to be jakarta.servlet:jakarta.servlet-api and uplift to 4.0.x.
This should be treated as a major version change, though there is no namespace change at this point.
Uplift some other dependencies.
Clean up some javadoc errors in build relating to deprecated methods.